### PR TITLE
Add Fluent API configs

### DIFF
--- a/TennisAcademy.Infrastructure/Configurations/CoachMediaConfiguration.cs
+++ b/TennisAcademy.Infrastructure/Configurations/CoachMediaConfiguration.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.Infrastructure.Configurations
+{
+    public class CoachMediaConfiguration : IEntityTypeConfiguration<CoachMedia>
+    {
+        public void Configure(EntityTypeBuilder<CoachMedia> builder)
+        {
+            builder.HasKey(cm => cm.Id);
+
+            builder.Property(cm => cm.Title)
+                   .IsRequired()
+                   .HasMaxLength(200);
+
+            builder.Property(cm => cm.FileUrl)
+                   .IsRequired()
+                   .HasMaxLength(500);
+
+            builder.HasOne(cm => cm.Coach)
+                   .WithMany()
+                   .HasForeignKey(cm => cm.CoachId)
+                   .OnDelete(DeleteBehavior.Restrict);
+        }
+    }
+}

--- a/TennisAcademy.Infrastructure/Configurations/CourseConfiguration.cs
+++ b/TennisAcademy.Infrastructure/Configurations/CourseConfiguration.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.Infrastructure.Configurations
+{
+    public class CourseConfiguration : IEntityTypeConfiguration<Course>
+    {
+        public void Configure(EntityTypeBuilder<Course> builder)
+        {
+            builder.HasKey(c => c.Id);
+
+            builder.Property(c => c.Title)
+                   .IsRequired()
+                   .HasMaxLength(200);
+
+            builder.Property(c => c.Description)
+                   .IsRequired();
+
+            builder.Property(c => c.VideoIntroUrl)
+                   .HasMaxLength(500);
+
+            builder.Property(c => c.CoverImageUrl)
+                   .HasMaxLength(500);
+
+            builder.Property(c => c.Price)
+                   .HasColumnType("decimal(18,2)");
+
+            builder.Property(c => c.IsActive)
+                   .HasDefaultValue(true);
+        }
+    }
+}

--- a/TennisAcademy.Infrastructure/Configurations/CourseVideoConfiguration.cs
+++ b/TennisAcademy.Infrastructure/Configurations/CourseVideoConfiguration.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.Infrastructure.Configurations
+{
+    public class CourseVideoConfiguration : IEntityTypeConfiguration<CourseVideo>
+    {
+        public void Configure(EntityTypeBuilder<CourseVideo> builder)
+        {
+            builder.HasKey(cv => cv.Id);
+
+            builder.Property(cv => cv.Title)
+                   .IsRequired()
+                   .HasMaxLength(200);
+
+            builder.Property(cv => cv.VideoUrl)
+                   .IsRequired()
+                   .HasMaxLength(500);
+
+            builder.HasOne(cv => cv.Course)
+                   .WithMany(c => c.Videos)
+                   .HasForeignKey(cv => cv.CourseId)
+                   .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/TennisAcademy.Infrastructure/Configurations/CreditHistoryConfiguration.cs
+++ b/TennisAcademy.Infrastructure/Configurations/CreditHistoryConfiguration.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.Infrastructure.Configurations
+{
+    public class CreditHistoryConfiguration : IEntityTypeConfiguration<CreditHistory>
+    {
+        public void Configure(EntityTypeBuilder<CreditHistory> builder)
+        {
+            builder.HasKey(ch => ch.Id);
+
+            builder.Property(ch => ch.Amount)
+                   .IsRequired();
+
+            builder.Property(ch => ch.Description)
+                   .IsRequired()
+                   .HasMaxLength(500);
+
+            builder.Property(ch => ch.CreatedAt)
+                   .IsRequired();
+
+            builder.HasOne(ch => ch.User)
+                   .WithMany()
+                   .HasForeignKey(ch => ch.UserId);
+        }
+    }
+}

--- a/TennisAcademy.Infrastructure/Configurations/PlanConfiguration.cs
+++ b/TennisAcademy.Infrastructure/Configurations/PlanConfiguration.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.Infrastructure.Configurations
+{
+    public class PlanConfiguration : IEntityTypeConfiguration<Plan>
+    {
+        public void Configure(EntityTypeBuilder<Plan> builder)
+        {
+            builder.HasKey(p => p.Id);
+
+            builder.Property(p => p.Title)
+                   .IsRequired()
+                   .HasMaxLength(200);
+
+            builder.Property(p => p.Description)
+                   .IsRequired();
+
+            builder.Property(p => p.Price)
+                   .HasColumnType("decimal(18,2)");
+        }
+    }
+}

--- a/TennisAcademy.Infrastructure/Configurations/PurchaseConfiguration.cs
+++ b/TennisAcademy.Infrastructure/Configurations/PurchaseConfiguration.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.Infrastructure.Configurations
+{
+    public class PurchaseConfiguration : IEntityTypeConfiguration<Purchase>
+    {
+        public void Configure(EntityTypeBuilder<Purchase> builder)
+        {
+            builder.HasKey(p => p.Id);
+
+            builder.Property(p => p.PurchaseDate)
+                   .HasDefaultValueSql("getutcdate()");
+
+            builder.HasOne(p => p.User)
+                   .WithMany(u => u.Purchases)
+                   .HasForeignKey(p => p.UserId);
+
+            builder.HasOne(p => p.Course)
+                   .WithMany(c => c.Purchases)
+                   .HasForeignKey(p => p.CourseId)
+                   .OnDelete(DeleteBehavior.Restrict);
+
+            builder.HasOne(p => p.Plan)
+                   .WithMany(pl => pl.Purchases)
+                   .HasForeignKey(p => p.PlanId)
+                   .OnDelete(DeleteBehavior.Restrict);
+        }
+    }
+}

--- a/TennisAcademy.Infrastructure/Configurations/TicketConfiguration.cs
+++ b/TennisAcademy.Infrastructure/Configurations/TicketConfiguration.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.Infrastructure.Configurations
+{
+    public class TicketConfiguration : IEntityTypeConfiguration<Ticket>
+    {
+        public void Configure(EntityTypeBuilder<Ticket> builder)
+        {
+            builder.HasKey(t => t.Id);
+
+            builder.Property(t => t.Subject)
+                   .IsRequired()
+                   .HasMaxLength(200);
+
+            builder.Property(t => t.Description)
+                   .IsRequired();
+
+            builder.Property(t => t.FileUrl)
+                   .HasMaxLength(500);
+
+            builder.Property(t => t.VoiceUrl)
+                   .HasMaxLength(500);
+
+            builder.Property(t => t.CoachReplyVoiceUrl)
+                   .HasMaxLength(500);
+
+            builder.Property(t => t.CoachReplyVideoUrl)
+                   .HasMaxLength(500);
+
+            builder.Property(t => t.CoachReply)
+                   .HasMaxLength(1000);
+
+            builder.Property(t => t.CreatedAt)
+                   .HasDefaultValueSql("getutcdate()");
+
+            builder.HasOne(t => t.User)
+                   .WithMany(u => u.Tickets)
+                   .HasForeignKey(t => t.UserId);
+
+            builder.HasOne(t => t.Coach)
+                   .WithMany()
+                   .HasForeignKey(t => t.CoachId)
+                   .OnDelete(DeleteBehavior.Restrict);
+        }
+    }
+}

--- a/TennisAcademy.Infrastructure/Configurations/UserConfiguration.cs
+++ b/TennisAcademy.Infrastructure/Configurations/UserConfiguration.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.Infrastructure.Configurations
+{
+    public class UserConfiguration : IEntityTypeConfiguration<User>
+    {
+        public void Configure(EntityTypeBuilder<User> builder)
+        {
+            builder.HasKey(u => u.Id);
+
+            builder.Property(u => u.FirstName)
+                   .IsRequired()
+                   .HasMaxLength(100);
+
+            builder.Property(u => u.LastName)
+                   .IsRequired()
+                   .HasMaxLength(100);
+
+            builder.Property(u => u.Email)
+                   .IsRequired()
+                   .HasMaxLength(255);
+
+            builder.Property(u => u.PasswordHash)
+                   .IsRequired()
+                   .HasMaxLength(255);
+
+            builder.Property(u => u.BirthYear)
+                   .IsRequired();
+
+            builder.Property(u => u.Credit)
+                   .HasDefaultValue(0);
+        }
+    }
+}

--- a/TennisAcademy.Infrastructure/Configurations/UserScoreConfiguration.cs
+++ b/TennisAcademy.Infrastructure/Configurations/UserScoreConfiguration.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.Infrastructure.Configurations
+{
+    public class UserScoreConfiguration : IEntityTypeConfiguration<UserScore>
+    {
+        public void Configure(EntityTypeBuilder<UserScore> builder)
+        {
+            builder.HasKey(us => us.Id);
+
+            builder.Property(us => us.Credit)
+                   .IsRequired();
+
+            builder.HasOne(us => us.User)
+                   .WithOne(u => u.UserScore)
+                   .HasForeignKey<UserScore>(us => us.UserId);
+        }
+    }
+}

--- a/TennisAcademy.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/TennisAcademy.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,10 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using TennisAcademy.Domain.Entities;
 
 namespace TennisAcademy.Infrastructure.Persistence
@@ -25,61 +19,10 @@ namespace TennisAcademy.Infrastructure.Persistence
         public DbSet<UserScore> UserScores { get; set; }
         public DbSet<CreditHistory> CreditHistories { get; set; }
 
-
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
-
-            // تنظیم رابطه‌ها و کلیدهای خارجی
-            modelBuilder.Entity<CourseVideo>()
-                .HasOne(cv => cv.Course)
-                .WithMany(c => c.Videos)
-                .HasForeignKey(cv => cv.CourseId)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            modelBuilder.Entity<Purchase>()
-                .HasOne(p => p.User)
-                .WithMany(u => u.Purchases)
-                .HasForeignKey(p => p.UserId);
-
-            modelBuilder.Entity<Purchase>()
-                .HasOne(p => p.Course)
-                .WithMany(c => c.Purchases)
-                .HasForeignKey(p => p.CourseId)
-                .OnDelete(DeleteBehavior.Restrict);
-
-            modelBuilder.Entity<Purchase>()
-                .HasOne(p => p.Plan)
-                .WithMany(pl => pl.Purchases)
-                .HasForeignKey(p => p.PlanId)
-                .OnDelete(DeleteBehavior.Restrict);
-
-            modelBuilder.Entity<Ticket>()
-                .HasOne(t => t.User)
-                .WithMany(u => u.Tickets)
-                .HasForeignKey(t => t.UserId);
-
-            modelBuilder.Entity<Ticket>()
-                .HasOne(t => t.Coach)
-                .WithMany()
-                .HasForeignKey(t => t.CoachId)
-                .OnDelete(DeleteBehavior.Restrict);
-            modelBuilder.Entity<CoachMedia>()
-    .HasOne(m => m.Coach)
-    .WithMany()
-    .HasForeignKey(m => m.CoachId)
-    .OnDelete(DeleteBehavior.Restrict);
-
-
-            modelBuilder.Entity<UserScore>()
-    .HasKey(us => us.Id);
-
-            modelBuilder.Entity<UserScore>()
-    .HasOne(us => us.User)
-    .WithOne(u => u.UserScore)
-    .HasForeignKey<UserScore>(us => us.UserId);
-
-
+            modelBuilder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add EF Core configuration classes for domain entities
- register configurations in ApplicationDbContext
- remove unused imports from ApplicationDbContext

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687478be7e288320ba5f8f8adabc1c08