### PR TITLE
Add refresh token support

### DIFF
--- a/TennisAcademy.API/Controllers/AuthController.cs
+++ b/TennisAcademy.API/Controllers/AuthController.cs
@@ -34,4 +34,13 @@ public class AuthController : ControllerBase
         return Ok(result);
     }
 
+    [HttpPost("refresh")]
+    public async Task<IActionResult> Refresh([FromBody] RefreshTokenDto dto)
+    {
+        var result = await _authService.RefreshTokenAsync(dto.Token, dto.RefreshToken);
+        if (result == null)
+            return Unauthorized();
+        return Ok(result);
+    }
+
 }

--- a/TennisAcademy.API/appsettings.json
+++ b/TennisAcademy.API/appsettings.json
@@ -11,7 +11,8 @@
       "Key": "ThisIsASecretKeyForJwtDontShareIt123!",
       "Issuer": "TennisAcademy",
       "Audience": "TennisAcademyUser",
-      "ExpireMinutes": 60
+      "ExpireMinutes": 60,
+      "RefreshTokenExpireDays": 7
     }
 
 

--- a/TennisAcademy.Application/DTOs/Auth/AuthResultDto.cs
+++ b/TennisAcademy.Application/DTOs/Auth/AuthResultDto.cs
@@ -12,6 +12,7 @@ namespace TennisAcademy.Application.DTOs.Auth
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string Role { get; set; }
+        public string RefreshToken { get; set; }
     }
 
 

--- a/TennisAcademy.Application/DTOs/Auth/RefreshTokenDto.cs
+++ b/TennisAcademy.Application/DTOs/Auth/RefreshTokenDto.cs
@@ -1,0 +1,9 @@
+namespace TennisAcademy.Application.DTOs.Auth
+{
+    public class RefreshTokenDto
+    {
+        public string Token { get; set; }
+        public string RefreshToken { get; set; }
+    }
+}
+

--- a/TennisAcademy.Application/Helpers/JwtSettings.cs
+++ b/TennisAcademy.Application/Helpers/JwtSettings.cs
@@ -12,6 +12,7 @@ namespace TennisAcademy.Application.Helpers
         public string Issuer { get; set; } = string.Empty;
         public string Audience { get; set; } = string.Empty;
         public int ExpireMinutes { get; set; }
+        public int RefreshTokenExpireDays { get; set; } = 7;
     }
 
 }

--- a/TennisAcademy.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/TennisAcademy.Application/Interfaces/Repositories/IUserRepository.cs
@@ -11,6 +11,7 @@ namespace TennisAcademy.Application.Interfaces.Repositories
     {
         Task<User?> GetByEmailAsync(string email);
         Task<User?> GetByIdAsync(Guid id);
+        Task<User?> GetByRefreshTokenAsync(string refreshToken);
         Task AddAsync(User user);
         void Update(User user);
         Task SaveChangesAsync();

--- a/TennisAcademy.Application/Interfaces/Services/IAuthService.cs
+++ b/TennisAcademy.Application/Interfaces/Services/IAuthService.cs
@@ -11,6 +11,7 @@ namespace TennisAcademy.Application.Interfaces.Services
     {
         Task<AuthResultDto> RegisterAsync(RegisterDto dto);
         Task<AuthResultDto> LoginAsync(LoginDto dto);
+        Task<AuthResultDto?> RefreshTokenAsync(string token, string refreshToken);
 
     }
 }

--- a/TennisAcademy.Application/Services/AuthService.cs
+++ b/TennisAcademy.Application/Services/AuthService.cs
@@ -20,12 +20,13 @@ namespace TennisAcademy.Application.Services
         private readonly IUserRepository _userRepo;
         private readonly IUserScoreRepository _userScoreRepository;
         private readonly JwtTokenGenerator _jwt;
-
-        public AuthService(IUserRepository userRepo, JwtTokenGenerator jwt, IUserScoreRepository userScoreRepository)
+        private readonly JwtSettings _settings;
+        public AuthService(IUserRepository userRepo, JwtTokenGenerator jwt, IUserScoreRepository userScoreRepository, Microsoft.Extensions.Options.IOptions<JwtSettings> options)
         {
             _userRepo = userRepo;
             _jwt = jwt;
             _userScoreRepository = userScoreRepository;
+            _settings = options.Value;
         }
 
         public async Task<AuthResultDto> RegisterAsync(RegisterDto dto)
@@ -45,7 +46,9 @@ namespace TennisAcademy.Application.Services
                 Role = Enum.Parse<UserRole>(dto.Role, ignoreCase: true),
                 BirthYear = dto.BirthYear,
                 TennisLevel = dto.TennisLevel,
-                TennisExperienceYears = dto.TennisExperienceYears
+                TennisExperienceYears = dto.TennisExperienceYears,
+                RefreshToken = GenerateRefreshToken(),
+                RefreshTokenExpiryTime = DateTime.UtcNow.AddDays(_settings.RefreshTokenExpireDays)
             };
 
 
@@ -68,7 +71,8 @@ namespace TennisAcademy.Application.Services
                 Token = token,
                 FirstName = user.FirstName,
                 LastName = user.LastName,
-                Role = user.Role.ToString()
+                Role = user.Role.ToString(),
+                RefreshToken = user.RefreshToken
             };
 
         }
@@ -88,13 +92,40 @@ namespace TennisAcademy.Application.Services
                 throw new FileNotFoundException("Invalid email or password.");
 
             var token = _jwt.GenerateToken(user);
+            user.RefreshToken = GenerateRefreshToken();
+            user.RefreshTokenExpiryTime = DateTime.UtcNow.AddDays(_settings.RefreshTokenExpireDays);
+            _userRepo.Update(user);
+            await _userRepo.SaveChangesAsync();
 
             return new AuthResultDto
             {
                 Token = token,
                 FirstName = user.FirstName,
                 LastName = user.LastName,
-                Role = user.Role.ToString()
+                Role = user.Role.ToString(),
+                RefreshToken = user.RefreshToken
+            };
+        }
+
+        public async Task<AuthResultDto?> RefreshTokenAsync(string token, string refreshToken)
+        {
+            var user = await _userRepo.GetByRefreshTokenAsync(refreshToken);
+            if (user == null || user.RefreshTokenExpiryTime <= DateTime.UtcNow)
+                return null;
+
+            var newToken = _jwt.GenerateToken(user);
+            user.RefreshToken = GenerateRefreshToken();
+            user.RefreshTokenExpiryTime = DateTime.UtcNow.AddDays(_settings.RefreshTokenExpireDays);
+            _userRepo.Update(user);
+            await _userRepo.SaveChangesAsync();
+
+            return new AuthResultDto
+            {
+                Token = newToken,
+                FirstName = user.FirstName,
+                LastName = user.LastName,
+                Role = user.Role.ToString(),
+                RefreshToken = user.RefreshToken
             };
         }
 
@@ -104,6 +135,14 @@ namespace TennisAcademy.Application.Services
             var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(password));
             var hash = Convert.ToBase64String(bytes);
             return hash == storedHash;
+        }
+
+        private string GenerateRefreshToken()
+        {
+            var randomNumber = new byte[32];
+            using var rng = RandomNumberGenerator.Create();
+            rng.GetBytes(randomNumber);
+            return Convert.ToBase64String(randomNumber);
         }
 
     }

--- a/TennisAcademy.Domain/Entities/User.cs
+++ b/TennisAcademy.Domain/Entities/User.cs
@@ -27,6 +27,10 @@ namespace TennisAcademy.Domain.Entities
 
         public int Credit { get; set; } = 0;
 
+        public string? RefreshToken { get; set; }
+
+        public DateTime RefreshTokenExpiryTime { get; set; }
+
         public ICollection<Ticket> Tickets { get; set; }
         public ICollection<Purchase> Purchases { get; set; }
         public UserScore UserScore { get; set; }

--- a/TennisAcademy.Infrastructure/Configurations/UserConfiguration.cs
+++ b/TennisAcademy.Infrastructure/Configurations/UserConfiguration.cs
@@ -31,6 +31,11 @@ namespace TennisAcademy.Infrastructure.Configurations
 
             builder.Property(u => u.Credit)
                    .HasDefaultValue(0);
+
+            builder.Property(u => u.RefreshToken)
+                   .HasMaxLength(200);
+
+            builder.Property(u => u.RefreshTokenExpiryTime);
         }
     }
 }

--- a/TennisAcademy.Infrastructure/Repositories/UserRepository.cs
+++ b/TennisAcademy.Infrastructure/Repositories/UserRepository.cs
@@ -29,6 +29,11 @@ namespace TennisAcademy.Infrastructure.Repositories
             return await _context.Users.FirstOrDefaultAsync(u => u.Id == id);
         }
 
+        public async Task<User?> GetByRefreshTokenAsync(string refreshToken)
+        {
+            return await _context.Users.FirstOrDefaultAsync(u => u.RefreshToken == refreshToken);
+        }
+
         public async Task AddAsync(User user)
         {
             await _context.Users.AddAsync(user);


### PR DESCRIPTION
## Summary
- store refresh tokens for users and configure EF mapping
- expose new refresh endpoint and DTOs
- refresh token handling in `AuthService`
- include refresh settings in configuration

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68789b2223cc8320852c24e582144b02