### PR TITLE
Add FluentValidation validators

### DIFF
--- a/TennisAcademy.API/Program.cs
+++ b/TennisAcademy.API/Program.cs
@@ -5,6 +5,9 @@ using TennisAcademy.Application.Helpers;
 using TennisAcademy.Application.Interfaces.Repositories;
 using TennisAcademy.Application.Interfaces.Services;
 using TennisAcademy.Application.Services;
+using FluentValidation;
+using FluentValidation.AspNetCore;
+using TennisAcademy.Application.Validators;
 using TennisAcademy.Infrastructure.Persistence;
 using TennisAcademy.Infrastructure.Repositories;
 var builder = WebApplication.CreateBuilder(args);
@@ -12,6 +15,8 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 
 builder.Services.AddControllers();
+builder.Services.AddValidatorsFromAssemblyContaining<RegisterDtoValidator>();
+builder.Services.AddFluentValidationAutoValidation();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 builder.Services.AddDbContext<ApplicationDbContext>(options =>

--- a/TennisAcademy.API/TennisAcademy.API.csproj
+++ b/TennisAcademy.API/TennisAcademy.API.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TennisAcademy.Application/Validators/AddCreditDtoValidator.cs
+++ b/TennisAcademy.Application/Validators/AddCreditDtoValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using TennisAcademy.Application.DTOs.UserScore;
+
+namespace TennisAcademy.Application.Validators;
+
+public class AddCreditDtoValidator : AbstractValidator<AddCreditDto>
+{
+    public AddCreditDtoValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.Amount).GreaterThan(0);
+    }
+}

--- a/TennisAcademy.Application/Validators/AnswerTicketDtoValidator.cs
+++ b/TennisAcademy.Application/Validators/AnswerTicketDtoValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+using TennisAcademy.Application.DTOs.Ticket;
+
+namespace TennisAcademy.Application.Validators;
+
+public class AnswerTicketDtoValidator : AbstractValidator<AnswerTicketDto>
+{
+    public AnswerTicketDtoValidator()
+    {
+        RuleFor(x => x.TicketId).NotEmpty();
+        // At least one response should be provided
+        RuleFor(x => x)
+            .Must(x => !string.IsNullOrWhiteSpace(x.CoachReply) ||
+                       !string.IsNullOrWhiteSpace(x.CoachReplyVoiceUrl) ||
+                       !string.IsNullOrWhiteSpace(x.CoachReplyVideoUrl) ||
+                       x.CoachVoiceMediaId.HasValue ||
+                       x.CoachVideoMediaId.HasValue)
+            .WithMessage("Reply content is required.");
+    }
+}

--- a/TennisAcademy.Application/Validators/CreateCoachMediaDtoValidator.cs
+++ b/TennisAcademy.Application/Validators/CreateCoachMediaDtoValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using TennisAcademy.Application.DTOs.CoachMedia;
+
+namespace TennisAcademy.Application.Validators;
+
+public class CreateCoachMediaDtoValidator : AbstractValidator<CreateCoachMediaDto>
+{
+    public CreateCoachMediaDtoValidator()
+    {
+        RuleFor(x => x.CoachId).NotEmpty();
+        RuleFor(x => x.Title).NotEmpty();
+        RuleFor(x => x.FileUrl).NotEmpty();
+    }
+}

--- a/TennisAcademy.Application/Validators/CreateCourseDtoValidator.cs
+++ b/TennisAcademy.Application/Validators/CreateCourseDtoValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using TennisAcademy.Application.DTOs.Course;
+
+namespace TennisAcademy.Application.Validators;
+
+public class CreateCourseDtoValidator : AbstractValidator<CreateCourseDto>
+{
+    public CreateCourseDtoValidator()
+    {
+        RuleFor(x => x.Title).NotEmpty();
+        RuleFor(x => x.Description).NotEmpty();
+        RuleFor(x => x.CoverImageUrl).NotEmpty();
+        RuleFor(x => x.VideoIntroUrl).NotEmpty();
+        RuleFor(x => x.Price).GreaterThan(0);
+    }
+}

--- a/TennisAcademy.Application/Validators/CreatePlanDtoValidator.cs
+++ b/TennisAcademy.Application/Validators/CreatePlanDtoValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using TennisAcademy.Application.DTOs.Plan;
+
+namespace TennisAcademy.Application.Validators;
+
+public class CreatePlanDtoValidator : AbstractValidator<CreatePlanDto>
+{
+    public CreatePlanDtoValidator()
+    {
+        RuleFor(x => x.Title).NotEmpty();
+        RuleFor(x => x.Description).NotEmpty();
+        RuleFor(x => x.Price).GreaterThan(0);
+    }
+}

--- a/TennisAcademy.Application/Validators/CreatePurchaseDtoValidator.cs
+++ b/TennisAcademy.Application/Validators/CreatePurchaseDtoValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using TennisAcademy.Application.DTOs.Purchase;
+
+namespace TennisAcademy.Application.Validators;
+
+public class CreatePurchaseDtoValidator : AbstractValidator<CreatePurchaseDto>
+{
+    public CreatePurchaseDtoValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x)
+            .Must(x => x.CourseId.HasValue || x.PlanId.HasValue)
+            .WithMessage("Either CourseId or PlanId is required.");
+    }
+}

--- a/TennisAcademy.Application/Validators/CreateTicketDtoValidator.cs
+++ b/TennisAcademy.Application/Validators/CreateTicketDtoValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using TennisAcademy.Application.DTOs.Ticket;
+
+namespace TennisAcademy.Application.Validators;
+
+public class CreateTicketDtoValidator : AbstractValidator<CreateTicketDto>
+{
+    public CreateTicketDtoValidator()
+    {
+        RuleFor(x => x.Subject).NotEmpty();
+        RuleFor(x => x.Description).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/TennisAcademy.Application/Validators/LoginDtoValidator.cs
+++ b/TennisAcademy.Application/Validators/LoginDtoValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using TennisAcademy.Application.DTOs.Auth;
+
+namespace TennisAcademy.Application.Validators;
+
+public class LoginDtoValidator : AbstractValidator<LoginDto>
+{
+    public LoginDtoValidator()
+    {
+        RuleFor(x => x.Email).NotEmpty().EmailAddress();
+        RuleFor(x => x.Password).NotEmpty();
+    }
+}

--- a/TennisAcademy.Application/Validators/RefreshTokenDtoValidator.cs
+++ b/TennisAcademy.Application/Validators/RefreshTokenDtoValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using TennisAcademy.Application.DTOs.Auth;
+
+namespace TennisAcademy.Application.Validators;
+
+public class RefreshTokenDtoValidator : AbstractValidator<RefreshTokenDto>
+{
+    public RefreshTokenDtoValidator()
+    {
+        RuleFor(x => x.Token).NotEmpty();
+        RuleFor(x => x.RefreshToken).NotEmpty();
+    }
+}

--- a/TennisAcademy.Application/Validators/RegisterDtoValidator.cs
+++ b/TennisAcademy.Application/Validators/RegisterDtoValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using TennisAcademy.Application.DTOs.Auth;
+
+namespace TennisAcademy.Application.Validators;
+
+public class RegisterDtoValidator : AbstractValidator<RegisterDto>
+{
+    public RegisterDtoValidator()
+    {
+        RuleFor(x => x.FirstName).NotEmpty().MaximumLength(50);
+        RuleFor(x => x.LastName).NotEmpty().MaximumLength(50);
+        RuleFor(x => x.Email).NotEmpty().EmailAddress();
+        RuleFor(x => x.Password).NotEmpty().MinimumLength(6);
+        RuleFor(x => x.BirthYear).NotEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- add FluentValidation.AspNetCore to API project
- register validators and auto-validation in Program
- implement validators for incoming DTOs in the Application layer

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68789f19abb88320878b907ba38b6244