### PR TITLE
Add course videos

### DIFF
--- a/TennisAcademy.API/Controllers/CourseController.cs
+++ b/TennisAcademy.API/Controllers/CourseController.cs
@@ -28,6 +28,7 @@ namespace TennisAcademy.API.Controllers
                 Description = c.Description,
                 Price = c.Price,
                 CoverImageUrl = c.CoverImageUrl,
+                TotalDurationMinutes = c.TotalDurationMinutes,
                 IsActive = c.IsActive
             });
 
@@ -47,6 +48,7 @@ namespace TennisAcademy.API.Controllers
                 Title = course.Title,
                 Description = course.Description,
                 CoverImageUrl = course.CoverImageUrl,
+                TotalDurationMinutes = course.TotalDurationMinutes,
                 Price = course.Price,
                 IsActive = course.IsActive
             });
@@ -62,6 +64,7 @@ namespace TennisAcademy.API.Controllers
                 Description = dto.Description,
                 CoverImageUrl = dto.CoverImageUrl,
                 VideoIntroUrl = dto.VideoIntroUrl,
+                TotalDurationMinutes = dto.TotalDurationMinutes,
                 Price = dto.Price,
                 IsActive = true
             };

--- a/TennisAcademy.API/Controllers/CourseVideoController.cs
+++ b/TennisAcademy.API/Controllers/CourseVideoController.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Mvc;
+using TennisAcademy.API.Extensions;
+using TennisAcademy.Application.DTOs.CourseVideo;
+using TennisAcademy.Application.Interfaces.Services;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CourseVideoController : ControllerBase
+    {
+        private readonly ICourseVideoService _service;
+
+        public CourseVideoController(ICourseVideoService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet("course/{courseId}")]
+        public async Task<IActionResult> GetByCourse(Guid courseId)
+        {
+            Guid? userId = null;
+            if (User.Identity?.IsAuthenticated == true)
+            {
+                userId = User.GetUserId();
+            }
+            var videos = await _service.GetVideosForUserAsync(courseId, userId);
+            var result = videos.Select(v => new CourseVideoDto
+            {
+                Id = v.Id,
+                Title = v.Title,
+                VideoUrl = v.VideoUrl,
+                DurationMinutes = v.DurationMinutes,
+                IsFreePreview = v.IsFreePreview
+            });
+            return Ok(result);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateCourseVideoDto dto)
+        {
+            var video = new CourseVideo
+            {
+                Id = Guid.NewGuid(),
+                CourseId = dto.CourseId,
+                Title = dto.Title,
+                VideoUrl = dto.VideoUrl,
+                DurationMinutes = dto.DurationMinutes,
+                IsFreePreview = dto.IsFreePreview
+            };
+            await _service.AddAsync(video);
+            return Ok();
+        }
+    }
+}

--- a/TennisAcademy.API/Program.cs
+++ b/TennisAcademy.API/Program.cs
@@ -39,6 +39,8 @@ builder.Services.AddScoped<IPurchaseService, PurchaseService>();
 builder.Services.AddScoped<IUserScoreService, UserScoreService>();
 builder.Services.AddScoped<IUserScoreRepository, UserScoreRepository>();
 builder.Services.AddScoped<ICreditHistoryRepository, CreditHistoryRepository>();
+builder.Services.AddScoped<ICourseVideoRepository, CourseVideoRepository>();
+builder.Services.AddScoped<ICourseVideoService, CourseVideoService>();
 
 
 

--- a/TennisAcademy.Application/DTOs/Course/CourseDto.cs
+++ b/TennisAcademy.Application/DTOs/Course/CourseDto.cs
@@ -16,6 +16,8 @@ namespace TennisAcademy.Application.DTOs.Course
 
         public string CoverImageUrl { get; set; }
 
+        public int TotalDurationMinutes { get; set; }
+
         public decimal Price { get; set; }
 
         public bool IsActive { get; set; }

--- a/TennisAcademy.Application/DTOs/Course/CreateCourseDto.cs
+++ b/TennisAcademy.Application/DTOs/Course/CreateCourseDto.cs
@@ -16,6 +16,8 @@ namespace TennisAcademy.Application.DTOs.Course
 
         public string VideoIntroUrl { get; set; }
 
+        public int TotalDurationMinutes { get; set; }
+
         public decimal Price { get; set; }
     }
 }

--- a/TennisAcademy.Application/DTOs/CourseVideo/CourseVideoDto.cs
+++ b/TennisAcademy.Application/DTOs/CourseVideo/CourseVideoDto.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TennisAcademy.Application.DTOs.CourseVideo
+{
+    public class CourseVideoDto
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; }
+        public string VideoUrl { get; set; }
+        public int DurationMinutes { get; set; }
+        public bool IsFreePreview { get; set; }
+    }
+}

--- a/TennisAcademy.Application/DTOs/CourseVideo/CreateCourseVideoDto.cs
+++ b/TennisAcademy.Application/DTOs/CourseVideo/CreateCourseVideoDto.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TennisAcademy.Application.DTOs.CourseVideo
+{
+    public class CreateCourseVideoDto
+    {
+        public Guid CourseId { get; set; }
+        public string Title { get; set; }
+        public string VideoUrl { get; set; }
+        public int DurationMinutes { get; set; }
+        public bool IsFreePreview { get; set; }
+    }
+}

--- a/TennisAcademy.Application/Interfaces/Repositories/ICourseVideoRepository.cs
+++ b/TennisAcademy.Application/Interfaces/Repositories/ICourseVideoRepository.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.Application.Interfaces.Repositories
+{
+    public interface ICourseVideoRepository
+    {
+        Task<List<CourseVideo>> GetByCourseIdAsync(Guid courseId);
+        Task AddAsync(CourseVideo video);
+        Task SaveChangesAsync();
+    }
+}

--- a/TennisAcademy.Application/Interfaces/Services/ICourseVideoService.cs
+++ b/TennisAcademy.Application/Interfaces/Services/ICourseVideoService.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.Application.Interfaces.Services
+{
+    public interface ICourseVideoService
+    {
+        Task<List<CourseVideo>> GetVideosForUserAsync(Guid courseId, Guid? userId);
+        Task AddAsync(CourseVideo video);
+    }
+}

--- a/TennisAcademy.Application/Services/CourseVideoService.cs
+++ b/TennisAcademy.Application/Services/CourseVideoService.cs
@@ -1,0 +1,46 @@
+using BuildingBlocks.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TennisAcademy.Application.Interfaces.Repositories;
+using TennisAcademy.Application.Interfaces.Services;
+using TennisAcademy.Domain.Entities;
+
+namespace TennisAcademy.Application.Services
+{
+    public class CourseVideoService : ICourseVideoService
+    {
+        private readonly ICourseVideoRepository _videoRepo;
+        private readonly IPurchaseRepository _purchaseRepo;
+
+        public CourseVideoService(ICourseVideoRepository videoRepo, IPurchaseRepository purchaseRepo)
+        {
+            _videoRepo = videoRepo;
+            _purchaseRepo = purchaseRepo;
+        }
+
+        public async Task<List<CourseVideo>> GetVideosForUserAsync(Guid courseId, Guid? userId)
+        {
+            var videos = await _videoRepo.GetByCourseIdAsync(courseId);
+            if (videos == null || !videos.Any())
+                throw new NotFoundException("No videos found for this course.");
+
+            if (userId.HasValue)
+            {
+                var purchases = await _purchaseRepo.GetByUserIdAsync(userId.Value);
+                var hasCourse = purchases.Any(p => p.CourseId == courseId);
+                if (hasCourse)
+                    return videos;
+            }
+
+            return videos.Where(v => v.IsFreePreview).ToList();
+        }
+
+        public async Task AddAsync(CourseVideo video)
+        {
+            await _videoRepo.AddAsync(video);
+            await _videoRepo.SaveChangesAsync();
+        }
+    }
+}

--- a/TennisAcademy.Domain/Entities/Course.cs
+++ b/TennisAcademy.Domain/Entities/Course.cs
@@ -18,6 +18,8 @@ namespace TennisAcademy.Domain.Entities
 
         public string CoverImageUrl { get; set; }
 
+        public int TotalDurationMinutes { get; set; }
+
         public decimal Price { get; set; }
 
         public bool IsActive { get; set; } = true;

--- a/TennisAcademy.Domain/Entities/CourseVideo.cs
+++ b/TennisAcademy.Domain/Entities/CourseVideo.cs
@@ -14,6 +14,8 @@ namespace TennisAcademy.Domain.Entities
 
         public string VideoUrl { get; set; }
 
+        public int DurationMinutes { get; set; }
+
         public bool IsFreePreview { get; set; }
 
         public Guid CourseId { get; set; }

--- a/TennisAcademy.Infrastructure/Configurations/CourseConfiguration.cs
+++ b/TennisAcademy.Infrastructure/Configurations/CourseConfiguration.cs
@@ -23,6 +23,8 @@ namespace TennisAcademy.Infrastructure.Configurations
             builder.Property(c => c.CoverImageUrl)
                    .HasMaxLength(500);
 
+            builder.Property(c => c.TotalDurationMinutes);
+
             builder.Property(c => c.Price)
                    .HasColumnType("decimal(18,2)");
 

--- a/TennisAcademy.Infrastructure/Configurations/CourseVideoConfiguration.cs
+++ b/TennisAcademy.Infrastructure/Configurations/CourseVideoConfiguration.cs
@@ -18,6 +18,8 @@ namespace TennisAcademy.Infrastructure.Configurations
                    .IsRequired()
                    .HasMaxLength(500);
 
+            builder.Property(cv => cv.DurationMinutes);
+
             builder.HasOne(cv => cv.Course)
                    .WithMany(c => c.Videos)
                    .HasForeignKey(cv => cv.CourseId)

--- a/TennisAcademy.Infrastructure/Repositories/CourseVideoRepository.cs
+++ b/TennisAcademy.Infrastructure/Repositories/CourseVideoRepository.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TennisAcademy.Application.Interfaces.Repositories;
+using TennisAcademy.Domain.Entities;
+using TennisAcademy.Infrastructure.Persistence;
+
+namespace TennisAcademy.Infrastructure.Repositories
+{
+    public class CourseVideoRepository : ICourseVideoRepository
+    {
+        private readonly ApplicationDbContext _context;
+
+        public CourseVideoRepository(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<List<CourseVideo>> GetByCourseIdAsync(Guid courseId)
+        {
+            return await _context.CourseVideos
+                .Where(v => v.CourseId == courseId)
+                .ToListAsync();
+        }
+
+        public async Task AddAsync(CourseVideo video)
+        {
+            await _context.CourseVideos.AddAsync(video);
+        }
+
+        public async Task SaveChangesAsync()
+        {
+            await _context.SaveChangesAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add video and total duration to course entities
- implement DTOs and services for course videos
- register course video services in API program
- expose endpoints for course videos

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688348f477788320b7e1b1664a11f1b5