### PR TITLE
Add profile avatar upload endpoint storing paths on accounts

### DIFF
--- a/MTA.Application/DTOs/UserDto.cs
+++ b/MTA.Application/DTOs/UserDto.cs
@@ -73,6 +73,7 @@ namespace MTA.Application.DTOs.User
         // Single media reference for account
         public int? MediaFileId { get; set; }
         public string? MediaFileUrl { get; set; }
+        public string? ProfileImagePath { get; set; }
     }
 
     // ======================

--- a/MTA.Application/Services/AccountService.cs
+++ b/MTA.Application/Services/AccountService.cs
@@ -1,4 +1,5 @@
-﻿using AutoMapper;
+using AutoMapper;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using MTA.Application.DTOs;
@@ -140,6 +141,7 @@ public class AccountService : IAccountService
             if (uploadedMedia != null)
             {
                 account.MediaFileId = uploadedMedia.Id; // یا MediaFileId
+                account.ProfileImagePath = uploadedMedia.Url;
             }
 
             // 3️⃣ ذخیره Account در دیتابیس
@@ -205,7 +207,7 @@ public class AccountService : IAccountService
             Id = account.Id,
             Email = account.Email,
             IsActive = account.IsActive,
-            ProfileImageUrl = account.MediaFile?.Url,
+            ProfileImageUrl = account.ProfileImagePath ?? account.MediaFile?.Url,
             FirstName = profile?.FirstName ?? string.Empty,
             LastName = profile?.LastName ?? string.Empty,
             DateOfBirth = profile?.DateOfBirth ?? DateTime.MinValue,
@@ -239,7 +241,11 @@ public class AccountService : IAccountService
             if (updateDto.StatusId.HasValue)
                 account.StatusId = updateDto.StatusId.Value;
             if (updateDto.MediaFileId.HasValue)
+            {
                 account.MediaFileId = updateDto.MediaFileId.Value;
+                var mediaFile = await _unitOfWork.Repository<MediaFile>().GetByIdAsync(updateDto.MediaFileId.Value);
+                account.ProfileImagePath = mediaFile?.Url;
+            }
 
 
             if (updateDto.Image != null && updateDto.Image.Length > 0)
@@ -254,6 +260,7 @@ public class AccountService : IAccountService
                 var uploadedMedia = await _mediaFileService.CreateAsync(updateDto.Image, mediaDto);
 
                 account.MediaFileId = uploadedMedia.Id;
+                account.ProfileImagePath = uploadedMedia.Url;
             }
 
             account.UpdatedAt = DateTime.UtcNow;
@@ -268,6 +275,48 @@ public class AccountService : IAccountService
             _logger.LogError(ex, "Error updating account with ID: {AccountId}", id);
             throw;
         }
+    }
+
+    public async Task<string?> UploadProfileImageAsync(int accountId, IFormFile profileImage)
+    {
+        if (profileImage == null || profileImage.Length == 0)
+        {
+            throw new ArgumentException("Profile image file is required.", nameof(profileImage));
+        }
+
+        var account = await _unitOfWork.Accounts.GetQueryable()
+            .Include(a => a.MediaFile)
+            .FirstOrDefaultAsync(a => a.Id == accountId);
+
+        if (account == null)
+        {
+            return null;
+        }
+
+        if (account.MediaFileId.HasValue)
+        {
+            await _mediaFileService.DeleteAsync(account.MediaFileId.Value);
+            account.MediaFileId = null;
+            account.ProfileImagePath = null;
+        }
+
+        var mediaDto = new MediaFileUploadDto
+        {
+            MediaType = "Account",
+            PlacementName = "ProfileImage",
+            Title = $"{account.Email} Profile Image"
+        };
+
+        var uploadedMedia = await _mediaFileService.CreateAsync(profileImage, mediaDto);
+
+        account.MediaFileId = uploadedMedia.Id;
+        account.ProfileImagePath = uploadedMedia.Url;
+        account.UpdatedAt = DateTime.UtcNow;
+
+        await _unitOfWork.Accounts.UpdateAsync(account);
+        await _unitOfWork.SaveChangesAsync();
+
+        return account.ProfileImagePath;
     }
 
     public async Task<CurrentUserDto?> UpdateCurrentUserAsync(int accountId, UpdateCurrentUserDto updateDto)
@@ -292,6 +341,7 @@ public class AccountService : IAccountService
             if (account.MediaFileId.HasValue)
             {
                 await _mediaFileService.DeleteAsync(account.MediaFileId.Value);
+                account.ProfileImagePath = null;
             }
 
             var mediaDto = new MediaFileUploadDto
@@ -302,6 +352,7 @@ public class AccountService : IAccountService
             };
             var uploadedMedia = await _mediaFileService.CreateAsync(updateDto.ProfileImage, mediaDto);
             account.MediaFileId = uploadedMedia.Id;
+            account.ProfileImagePath = uploadedMedia.Url;
         }
 
         // --- UserProfile fields ---
@@ -458,7 +509,7 @@ public class AccountService : IAccountService
             Id = account.Id,
             Email = account.Email,
             IsActive = account.IsActive,
-            Image = account.MediaFile?.Url ?? string.Empty,
+            Image = account.ProfileImagePath ?? account.MediaFile?.Url ?? string.Empty,
             RoleId = account.RoleId,
             RoleTitle = account.Role?.Title ?? string.Empty,
             StatusId = account.StatusId,
@@ -467,6 +518,7 @@ public class AccountService : IAccountService
             UpdatedAt = account.UpdatedAt,
             MediaFileId = account.MediaFileId,
             MediaFileUrl = account.MediaFile?.Url ?? string.Empty,
+            ProfileImagePath = account.ProfileImagePath,
             UserProfile = account.UserProfile != null ? new UserProfileDto
             {
                 Id = account.UserProfile.Id,
@@ -477,7 +529,7 @@ public class AccountService : IAccountService
                 AccountId = account.UserProfile.AccountId,
                 SkillLevelId = account.UserProfile.SkillLevelId,
                 SkillLevelValue = account.UserProfile.SkillLevel?.Title ?? "Beginner",
-                AvatarUrl = account.MediaFile?.Url ?? string.Empty,
+                AvatarUrl = account.ProfileImagePath ?? account.MediaFile?.Url ?? string.Empty,
                 CreatedAt = account.UserProfile.CreatedAt,
                 UpdatedAt = account.UserProfile.UpdatedAt,
                 HealthCondition = account.UserProfile.HealthCondition,

--- a/MTA.Application/Services/IAccountService.cs
+++ b/MTA.Application/Services/IAccountService.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using MTA.Application.DTOs;
 using MTA.Application.DTOs.User;
 
@@ -21,6 +22,8 @@ public interface IAccountService
     Task<CurrentUserDto?> UpdateCurrentUserAsync(int accountId, UpdateCurrentUserDto updateDto);
 
     Task<CurrentUserDto?> GetCurrentUserAsync(int accountId);
+
+    Task<string?> UploadProfileImageAsync(int accountId, IFormFile profileImage);
     /// <summary>
     /// Get account by email
     /// </summary>

--- a/MTA.Domain/Entities/Account.cs
+++ b/MTA.Domain/Entities/Account.cs
@@ -12,6 +12,8 @@ public class Account : BaseEntity
     
     public bool IsActive { get; set; } = true;
 
+    public string? ProfileImagePath { get; set; }
+
     public int? MediaFileId { get; set; }
     [ForeignKey(nameof(MediaFileId))]
     public virtual MediaFile? MediaFile { get; set; }

--- a/MTA.Infrastructure/Data/ApplicationDbContext.cs
+++ b/MTA.Infrastructure/Data/ApplicationDbContext.cs
@@ -83,10 +83,11 @@ public class ApplicationDbContext : DbContext
 		modelBuilder.Entity<Account>(entity =>
 		{
 			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Email).IsRequired().HasMaxLength(255);
-			entity.Property(e => e.Password).IsRequired().HasMaxLength(255);
+                        entity.Property(e => e.Email).IsRequired().HasMaxLength(255);
+                        entity.Property(e => e.Password).IsRequired().HasMaxLength(255);
+                        entity.Property(e => e.ProfileImagePath).HasMaxLength(1000);
 
-			entity.HasIndex(e => e.Email).IsUnique();
+                        entity.HasIndex(e => e.Email).IsUnique();
 
 			entity.HasOne(e => e.Role)
 				.WithMany(r => r.Accounts)

--- a/MTA.Infrastructure/Migrations/20251001000000_AddProfileImagePathToAccount.cs
+++ b/MTA.Infrastructure/Migrations/20251001000000_AddProfileImagePathToAccount.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MTA.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProfileImagePathToAccount : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProfileImagePath",
+                table: "Accounts",
+                type: "nvarchar(1000)",
+                maxLength: 1000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProfileImagePath",
+                table: "Accounts");
+        }
+    }
+}

--- a/MTA.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/MTA.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -44,6 +44,10 @@ namespace MTA.Infrastructure.Migrations
                     b.Property<int?>("MediaFileId")
                         .HasColumnType("int");
 
+                    b.Property<string>("ProfileImagePath")
+                        .HasMaxLength(1000)
+                        .HasColumnType("nvarchar(1000)");
+
                     b.Property<string>("Password")
                         .IsRequired()
                         .HasMaxLength(255)

--- a/MTA.Web/Controllers/ProfileController.cs
+++ b/MTA.Web/Controllers/ProfileController.cs
@@ -1,6 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs.User;
 using MTA.Application.Services;
+using MTA.Web.Models;
 
 namespace MTA.Web.Controllers
 {
@@ -16,29 +19,72 @@ namespace MTA.Web.Controllers
             _accountService = accountService;
         }
 
-        [HttpGet]
-        public async Task<ActionResult<CurrentUserDto>> GetCurrentUser()
+        [HttpGet("[action]")]
+        [ProducesResponseType(typeof(CustomJsonResult<CurrentUserDto>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.Unauthorized)]
+        public async Task<ActionResult<CustomJsonResult<CurrentUserDto>>> GetCurrentUser()
         {
-            int userId = int.Parse(User.FindFirst("UserId")?.Value ?? "0");
-            if (userId == 0) return Unauthorized();
+            if (!int.TryParse(User.FindFirst("UserId")?.Value, out var userId) || userId == 0)
+            {
+                return Unauthorized(CustomJsonResult<string>.Failure("User is not authenticated."));
+            }
 
             var user = await _accountService.GetCurrentUserAsync(userId);
-            if (user == null) return NotFound();
+            if (user == null)
+            {
+                return NotFound(CustomJsonResult<string>.Failure("User not found."));
+            }
 
-            return Ok(user);
+            return Ok(CustomJsonResult<CurrentUserDto>.SuccessResult(user));
         }
 
-        [HttpPut]
-        public async Task<ActionResult<CurrentUserDto>> UpdateCurrentUser([FromForm] UpdateCurrentUserDto updateDto)
+        [HttpPut("[action]")]
+        [ProducesResponseType(typeof(CustomJsonResult<CurrentUserDto>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.Unauthorized)]
+        public async Task<ActionResult<CustomJsonResult<CurrentUserDto>>> UpdateCurrentUser([FromForm] UpdateCurrentUserDto updateDto)
         {
-            int userId = int.Parse(User.FindFirst("UserId")?.Value ?? "0");
-            if (userId == 0) return Unauthorized();
+            if (!int.TryParse(User.FindFirst("UserId")?.Value, out var userId) || userId == 0)
+            {
+                return Unauthorized(CustomJsonResult<string>.Failure("User is not authenticated."));
+            }
 
             var updatedUser = await _accountService.UpdateCurrentUserAsync(userId, updateDto);
-            if (updatedUser == null) return NotFound();
+            if (updatedUser == null)
+            {
+                return NotFound(CustomJsonResult<string>.Failure("User not found."));
+            }
 
-            return Ok(updatedUser);
+            return Ok(CustomJsonResult<CurrentUserDto>.SuccessResult(updatedUser));
+        }
+
+        [HttpPost("[action]")]
+        [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.Unauthorized)]
+        public async Task<ActionResult<CustomJsonResult<string>>> UploadAvatar([FromForm] IFormFile profileImage)
+        {
+            if (profileImage == null || profileImage.Length == 0)
+            {
+                return BadRequest(CustomJsonResult<string>.Failure("Profile image file is required."));
+            }
+
+            if (!int.TryParse(User.FindFirst("UserId")?.Value, out var userId) || userId == 0)
+            {
+                return Unauthorized(CustomJsonResult<string>.Failure("User is not authenticated."));
+            }
+
+            var profileImagePath = await _accountService.UploadProfileImageAsync(userId, profileImage);
+            if (profileImagePath == null)
+            {
+                return NotFound(CustomJsonResult<string>.Failure("User not found."));
+            }
+
+            return Ok(CustomJsonResult<string>.SuccessResult(profileImagePath));
         }
     }
-
 }

--- a/MTA.Web/Models/CustomJsonResult.cs
+++ b/MTA.Web/Models/CustomJsonResult.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace MTA.Web.Models;
+
+public class CustomJsonResult<T>
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; init; }
+
+    [JsonPropertyName("data")]
+    public T? Data { get; init; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+
+    public static CustomJsonResult<T> SuccessResult(T data) => new()
+    {
+        Success = true,
+        Data = data
+    };
+
+    public static CustomJsonResult<T> Failure(string error) => new()
+    {
+        Success = false,
+        Error = error
+    };
+}


### PR DESCRIPTION
## Summary
- add a profile image path column to accounts and update the EF model/migration snapshot
- extend the account service to persist and expose profile avatar uploads and new path data
- wrap profile controller responses in CustomJsonResult and expose an upload endpoint that saves avatars to wwwroot

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fb2c71741c83208e1e0c72f0990025