### PR TITLE
Refactor EF Core configurations into dedicated classes

### DIFF
--- a/MTA.Infrastructure/Data/ApplicationDbContext.cs
+++ b/MTA.Infrastructure/Data/ApplicationDbContext.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using MTA.Domain.Entities;
 
 namespace MTA.Infrastructure.Data;
@@ -8,346 +8,32 @@ namespace MTA.Infrastructure.Data;
 /// </summary>
 public class ApplicationDbContext : DbContext
 {
-	public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
 
-	// DbSet properties
-	public DbSet<Level> Levels { get; set; }
-	public DbSet<Role> Roles { get; set; }
-	public DbSet<Permission> Permissions { get; set; }
-	public DbSet<UserProfile> UserProfiles { get; set; }
-	public DbSet<Account> Accounts { get; set; }
-	public DbSet<Course> Courses { get; set; }
-	public DbSet<Lesson> Lessons { get; set; }
-	public DbSet<MediaFile> MediaFiles { get; set; }
-	public DbSet<Package> Packages { get; set; }
-	public DbSet<Ticket> Tickets { get; set; }
-	public DbSet<Message> Messages { get; set; }
-	public DbSet<PermissionsRole> PermissionsRoles { get; set; }
-	public DbSet<UserCourseHistory> UserCourseHistories { get; set; }
-	public DbSet<PackageHistory> PackageHistories { get; set; }
-	public DbSet<Lookup> Lookups { get; set; }
-	public DbSet<FAQCategory> FAQCategories { get; set; }
-	public DbSet<QuestionFAQ> QuestionFAQs { get; set; }
-	public DbSet<RefreshToken> RefreshTokens { get; set; }
+    // DbSet properties
+    public DbSet<Level> Levels { get; set; }
+    public DbSet<Role> Roles { get; set; }
+    public DbSet<Permission> Permissions { get; set; }
+    public DbSet<UserProfile> UserProfiles { get; set; }
+    public DbSet<Account> Accounts { get; set; }
+    public DbSet<Course> Courses { get; set; }
+    public DbSet<Lesson> Lessons { get; set; }
+    public DbSet<MediaFile> MediaFiles { get; set; }
+    public DbSet<Package> Packages { get; set; }
+    public DbSet<Ticket> Tickets { get; set; }
+    public DbSet<Message> Messages { get; set; }
+    public DbSet<PermissionsRole> PermissionsRoles { get; set; }
+    public DbSet<UserCourseHistory> UserCourseHistories { get; set; }
+    public DbSet<PackageHistory> PackageHistories { get; set; }
+    public DbSet<Lookup> Lookups { get; set; }
+    public DbSet<FAQCategory> FAQCategories { get; set; }
+    public DbSet<QuestionFAQ> QuestionFAQs { get; set; }
+    public DbSet<RefreshToken> RefreshTokens { get; set; }
 
-	protected override void OnModelCreating(ModelBuilder modelBuilder)
-	{
-		base.OnModelCreating(modelBuilder);
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
 
-		// --- Level ---
-		modelBuilder.Entity<Level>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Title).IsRequired().HasMaxLength(100);
-			entity.HasIndex(e => e.Title).IsUnique();
-		});
-
-		// --- Role ---
-		modelBuilder.Entity<Role>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Title).IsRequired().HasMaxLength(100);
-			entity.HasIndex(e => e.Title).IsUnique();
-		});
-
-		// --- Permission ---
-		modelBuilder.Entity<Permission>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Title).IsRequired().HasMaxLength(100);
-			entity.Property(e => e.Description).HasMaxLength(500);
-			entity.HasIndex(e => e.Title).IsUnique();
-		});
-
-		// --- UserProfile ---
-		modelBuilder.Entity<UserProfile>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.FirstName).IsRequired().HasMaxLength(100);
-			entity.Property(e => e.LastName).IsRequired().HasMaxLength(100);
-			entity.Property(e => e.DateOfBirth).IsRequired();
-			entity.Property(e => e.Experience).IsRequired();
-
-			entity.HasOne(e => e.Account)
-				.WithOne(a => a.UserProfile)
-				.HasForeignKey<UserProfile>(e => e.AccountId)
-				.OnDelete(DeleteBehavior.Cascade);
-
-			entity.HasOne(e => e.SkillLevel)
-				.WithMany()
-				.HasForeignKey(e => e.SkillLevelId)
-				.OnDelete(DeleteBehavior.Restrict);
-		});
-
-		// --- Account ---
-		modelBuilder.Entity<Account>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-                        entity.Property(e => e.Email).IsRequired().HasMaxLength(255);
-                        entity.Property(e => e.Password).IsRequired().HasMaxLength(255);
-                        entity.Property(e => e.ProfileImagePath).HasMaxLength(1000);
-
-                        entity.HasIndex(e => e.Email).IsUnique();
-
-			entity.HasOne(e => e.Role)
-				.WithMany(r => r.Accounts)
-				.HasForeignKey(e => e.RoleId)
-				.OnDelete(DeleteBehavior.Restrict);
-
-			entity.HasOne(e => e.Status)
-				.WithMany()
-				.HasForeignKey(e => e.StatusId)
-				.OnDelete(DeleteBehavior.Restrict);
-
-			// Account -> MediaFile (single)
-			entity.HasOne(e => e.MediaFile)
-				.WithMany()
-				.HasForeignKey(e => e.MediaFileId)
-				.OnDelete(DeleteBehavior.Restrict);
-		});
-
-		// --- Course ---
-		modelBuilder.Entity<Course>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
-			entity.Property(e => e.Description).HasMaxLength(2000);
-			entity.Property(e => e.Price).HasColumnType("decimal(18,2)");
-
-			// Icon MediaFile
-			entity.HasOne(e => e.IconMediaFile)
-				  .WithMany()
-				  .HasForeignKey(e => e.IconMediaFileId)
-				  .OnDelete(DeleteBehavior.Restrict);
-
-			// Poster MediaFile
-			entity.HasOne(e => e.PosterMediaFile)
-				  .WithMany()
-				  .HasForeignKey(e => e.PosterMediaFileId)
-				  .OnDelete(DeleteBehavior.Restrict);
-
-			entity.HasOne(e => e.Level)
-				.WithMany(e => e.Courses)
-				.HasForeignKey(e => e.LevelId)
-				.OnDelete(DeleteBehavior.Restrict);
-
-			entity.HasOne(e => e.Status)
-				.WithMany()
-				.HasForeignKey(e => e.StatusId)
-				.OnDelete(DeleteBehavior.Restrict);
-		});
-
-		// --- Lesson ---
-		modelBuilder.Entity<Lesson>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
-			entity.Property(e => e.Description).HasMaxLength(2000);
-
-			entity.HasOne(e => e.Course)
-				.WithMany(c => c.Lessons)
-				.HasForeignKey(e => e.CourseId)
-				.OnDelete(DeleteBehavior.Cascade);
-
-			// Lesson -> MediaFile (single)
-			entity.HasOne(e => e.MediaFile)
-				.WithMany()
-				.HasForeignKey(e => e.MediaFileId)
-				.OnDelete(DeleteBehavior.Restrict);
-		});
-
-		// --- MediaFile ---
-		modelBuilder.Entity<MediaFile>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
-			entity.Property(e => e.Url).IsRequired().HasMaxLength(1000);
-
-			entity.HasOne(e => e.Type)
-				.WithMany()
-				.HasForeignKey(e => e.TypeId)
-				.OnDelete(DeleteBehavior.Restrict);
-		});
-
-		// --- Package ---
-		modelBuilder.Entity<Package>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
-			entity.Property(e => e.Price).HasColumnType("decimal(18,2)");
-			entity.Property(e => e.TicketCount).IsRequired();
-			entity.Property(e => e.MessageCount).IsRequired();
-			entity.Property(e => e.Duration).IsRequired();
-
-			entity.HasOne(e => e.DurationUnit)
-				.WithMany()
-				.HasForeignKey(e => e.DurationUnitId)
-				.OnDelete(DeleteBehavior.Restrict);
-		});
-
-		// --- Ticket ---
-		modelBuilder.Entity<Ticket>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Topic).IsRequired().HasMaxLength(200);
-
-			entity.HasOne(e => e.Status)
-				.WithMany()
-				.HasForeignKey(e => e.StatusId)
-				.OnDelete(DeleteBehavior.Restrict);
-
-			entity.HasOne(e => e.Account)
-				.WithMany()
-				.HasForeignKey(e => e.AccountId)
-				.OnDelete(DeleteBehavior.Restrict);
-
-			entity.HasOne(e => e.Package)
-				.WithMany()
-				.HasForeignKey(e => e.PackageId)
-				.OnDelete(DeleteBehavior.Restrict);
-		});
-
-		// --- Message ---
-		modelBuilder.Entity<Message>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Text).IsRequired().HasMaxLength(2000);
-
-			entity.HasOne(e => e.Ticket)
-				.WithMany(e => e.Messages)
-				.HasForeignKey(e => e.TicketId)
-				.OnDelete(DeleteBehavior.Cascade);
-
-			entity.HasOne(e => e.Sender)
-				.WithMany()
-				.HasForeignKey(e => e.SenderId)
-				.OnDelete(DeleteBehavior.Restrict);
-		});
-
-		// --- PermissionsRole ---
-		modelBuilder.Entity<PermissionsRole>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-
-			entity.HasOne(e => e.Role)
-				.WithMany(e => e.RolePermissions)
-				.HasForeignKey(e => e.RoleId)
-				.OnDelete(DeleteBehavior.Cascade);
-
-			entity.HasOne(e => e.Permission)
-				.WithMany(e => e.PermissionsRoles)
-				.HasForeignKey(e => e.PermissionId)
-				.OnDelete(DeleteBehavior.Cascade);
-		});
-
-		// --- UserCourseHistory ---
-		modelBuilder.Entity<UserCourseHistory>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-
-			entity.HasOne(e => e.Course)
-				.WithMany(e => e.UserCourseHistory)
-				.HasForeignKey(e => e.CourseId)
-				.OnDelete(DeleteBehavior.Restrict);
-
-			entity.HasOne(e => e.Account)
-				.WithMany(e => e.UserCourseHistory)
-				.HasForeignKey(e => e.AccountId)
-				.OnDelete(DeleteBehavior.Restrict);
-		});
-
-		// --- PackageHistory ---
-		modelBuilder.Entity<PackageHistory>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.ExpiredDate).IsRequired();
-			entity.Property(e => e.RemainingTickets).IsRequired();
-			entity.Property(e => e.RemainingMessages).IsRequired();
-
-			entity.HasOne(e => e.Package)
-				.WithMany(e => e.PackageHistories)
-				.HasForeignKey(e => e.PackageId)
-				.OnDelete(DeleteBehavior.Restrict);
-
-			entity.HasOne(e => e.Account)
-				.WithMany(e => e.PackageHistory)
-				.HasForeignKey(e => e.AccountId)
-				.OnDelete(DeleteBehavior.Restrict);
-		});
-
-		// Configure Lookup entity
-		modelBuilder.Entity<Lookup>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Category).IsRequired().HasMaxLength(100);
-			entity.Property(e => e.Key).IsRequired().HasMaxLength(100);
-			entity.Property(e => e.Value).IsRequired().HasMaxLength(200);
-			
-			// Composite unique index on Category and Key
-			entity.HasIndex(e => new { e.Category, e.Key }).IsUnique();
-		});
-
-		// Configure FAQCategory entity
-		modelBuilder.Entity<FAQCategory>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
-			entity.Property(e => e.Description).HasMaxLength(1000);
-			entity.Property(e => e.SortOrder).IsRequired();
-			entity.Property(e => e.IsActive).IsRequired();
-			
-			// Relationship with Questions
-			entity.HasMany(e => e.Questions)
-				.WithOne(e => e.Category)
-				.HasForeignKey(e => e.CategoryId)
-				.OnDelete(DeleteBehavior.Cascade);
-		});
-
-		// Configure QuestionFAQ entity
-		modelBuilder.Entity<QuestionFAQ>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.QuestionText).IsRequired().HasMaxLength(2000);
-			entity.Property(e => e.AnswerText).IsRequired().HasMaxLength(5000);
-			entity.Property(e => e.IsActive).IsRequired();
-			
-			// Relationship with Category
-			entity.HasOne(e => e.Category)
-				.WithMany(e => e.Questions)
-				.HasForeignKey(e => e.CategoryId)
-				.OnDelete(DeleteBehavior.Restrict);
-		});
-		modelBuilder.Entity<Lookup>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Category).IsRequired().HasMaxLength(100);
-			entity.Property(e => e.Key).IsRequired().HasMaxLength(100);
-			entity.Property(e => e.Value).IsRequired().HasMaxLength(200);
-		});
-
-		// --- FAQCategory ---
-		modelBuilder.Entity<FAQCategory>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
-		});
-
-		// --- QuestionFAQ ---
-		modelBuilder.Entity<QuestionFAQ>(entity =>
-		{
-			entity.HasKey(e => e.Id);
-			entity.Property(e => e.QuestionText).IsRequired().HasMaxLength(500);
-			entity.Property(e => e.AnswerText).IsRequired();
-
-			entity.HasOne(e => e.Category)
-				.WithMany(c => c.Questions)
-				.HasForeignKey(e => e.CategoryId)
-				.OnDelete(DeleteBehavior.Cascade);
-		});
-
-		//LookupSeed.Seed(modelBuilder);
-		//RoleSeed.Seed(modelBuilder);
-		//LevelSeed.Seed(modelBuilder);
-		//PermissionSeed.Seed(modelBuilder);
-	}
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
+    }
 }

--- a/MTA.Infrastructure/Data/Configurations/Account/AccountConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/Account/AccountConfiguration.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.Account;
+
+public class AccountConfiguration : IEntityTypeConfiguration<Account>
+{
+    public void Configure(EntityTypeBuilder<Account> builder)
+    {
+        builder.HasKey(account => account.Id);
+
+        builder.Property(account => account.Email)
+            .IsRequired()
+            .HasMaxLength(255);
+
+        builder.Property(account => account.Password)
+            .IsRequired()
+            .HasMaxLength(255);
+
+        builder.Property(account => account.ProfileImagePath)
+            .HasMaxLength(1000);
+
+        builder.HasIndex(account => account.Email)
+            .IsUnique();
+
+        builder.HasOne(account => account.Role)
+            .WithMany(role => role.Accounts)
+            .HasForeignKey(account => account.RoleId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(account => account.Status)
+            .WithMany()
+            .HasForeignKey(account => account.StatusId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(account => account.MediaFile)
+            .WithMany()
+            .HasForeignKey(account => account.MediaFileId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/Course/CourseConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/Course/CourseConfiguration.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.Course;
+
+public class CourseConfiguration : IEntityTypeConfiguration<Course>
+{
+    public void Configure(EntityTypeBuilder<Course> builder)
+    {
+        builder.HasKey(course => course.Id);
+
+        builder.Property(course => course.Title)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(course => course.Description)
+            .HasMaxLength(2000);
+
+        builder.Property(course => course.Price)
+            .HasColumnType("decimal(18,2)");
+
+        builder.HasOne(course => course.IconMediaFile)
+            .WithMany()
+            .HasForeignKey(course => course.IconMediaFileId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(course => course.PosterMediaFile)
+            .WithMany()
+            .HasForeignKey(course => course.PosterMediaFileId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(course => course.Level)
+            .WithMany(level => level.Courses)
+            .HasForeignKey(course => course.LevelId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(course => course.Status)
+            .WithMany()
+            .HasForeignKey(course => course.StatusId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/FAQCategory/FAQCategoryConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/FAQCategory/FAQCategoryConfiguration.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.FAQCategory;
+
+public class FAQCategoryConfiguration : IEntityTypeConfiguration<FAQCategory>
+{
+    public void Configure(EntityTypeBuilder<FAQCategory> builder)
+    {
+        builder.HasKey(category => category.Id);
+
+        builder.Property(category => category.Title)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(category => category.Description)
+            .HasMaxLength(1000);
+
+        builder.Property(category => category.SortOrder)
+            .IsRequired();
+
+        builder.Property(category => category.IsActive)
+            .IsRequired();
+
+        builder.HasMany(category => category.Questions)
+            .WithOne(question => question.Category)
+            .HasForeignKey(question => question.CategoryId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/Lesson/LessonConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/Lesson/LessonConfiguration.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.Lesson;
+
+public class LessonConfiguration : IEntityTypeConfiguration<Lesson>
+{
+    public void Configure(EntityTypeBuilder<Lesson> builder)
+    {
+        builder.HasKey(lesson => lesson.Id);
+
+        builder.Property(lesson => lesson.Title)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(lesson => lesson.Description)
+            .HasMaxLength(2000);
+
+        builder.HasOne(lesson => lesson.Course)
+            .WithMany(course => course.Lessons)
+            .HasForeignKey(lesson => lesson.CourseId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(lesson => lesson.MediaFile)
+            .WithMany()
+            .HasForeignKey(lesson => lesson.MediaFileId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/Level/LevelConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/Level/LevelConfiguration.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.Level;
+
+public class LevelConfiguration : IEntityTypeConfiguration<Level>
+{
+    public void Configure(EntityTypeBuilder<Level> builder)
+    {
+        builder.HasKey(level => level.Id);
+
+        builder.Property(level => level.Title)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.HasIndex(level => level.Title)
+            .IsUnique();
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/Lookup/LookupConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/Lookup/LookupConfiguration.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.Lookup;
+
+public class LookupConfiguration : IEntityTypeConfiguration<Lookup>
+{
+    public void Configure(EntityTypeBuilder<Lookup> builder)
+    {
+        builder.HasKey(lookup => lookup.Id);
+
+        builder.Property(lookup => lookup.Category)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(lookup => lookup.Key)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(lookup => lookup.Value)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.HasIndex(lookup => new { lookup.Category, lookup.Key })
+            .IsUnique();
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/MediaFile/MediaFileConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/MediaFile/MediaFileConfiguration.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.MediaFile;
+
+public class MediaFileConfiguration : IEntityTypeConfiguration<MediaFile>
+{
+    public void Configure(EntityTypeBuilder<MediaFile> builder)
+    {
+        builder.HasKey(mediaFile => mediaFile.Id);
+
+        builder.Property(mediaFile => mediaFile.Title)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(mediaFile => mediaFile.Url)
+            .IsRequired()
+            .HasMaxLength(1000);
+
+        builder.HasOne(mediaFile => mediaFile.Type)
+            .WithMany()
+            .HasForeignKey(mediaFile => mediaFile.TypeId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/Message/MessageConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/Message/MessageConfiguration.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.Message;
+
+public class MessageConfiguration : IEntityTypeConfiguration<Message>
+{
+    public void Configure(EntityTypeBuilder<Message> builder)
+    {
+        builder.HasKey(message => message.Id);
+
+        builder.Property(message => message.Text)
+            .IsRequired()
+            .HasMaxLength(2000);
+
+        builder.HasOne(message => message.Ticket)
+            .WithMany(ticket => ticket.Messages)
+            .HasForeignKey(message => message.TicketId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(message => message.Sender)
+            .WithMany()
+            .HasForeignKey(message => message.SenderId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/Package/PackageConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/Package/PackageConfiguration.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.Package;
+
+public class PackageConfiguration : IEntityTypeConfiguration<Package>
+{
+    public void Configure(EntityTypeBuilder<Package> builder)
+    {
+        builder.HasKey(package => package.Id);
+
+        builder.Property(package => package.Title)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(package => package.Price)
+            .HasColumnType("decimal(18,2)");
+
+        builder.Property(package => package.TicketCount)
+            .IsRequired();
+
+        builder.Property(package => package.MessageCount)
+            .IsRequired();
+
+        builder.Property(package => package.Duration)
+            .IsRequired();
+
+        builder.HasOne(package => package.DurationUnit)
+            .WithMany()
+            .HasForeignKey(package => package.DurationUnitId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/PackageHistory/PackageHistoryConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/PackageHistory/PackageHistoryConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.PackageHistory;
+
+public class PackageHistoryConfiguration : IEntityTypeConfiguration<PackageHistory>
+{
+    public void Configure(EntityTypeBuilder<PackageHistory> builder)
+    {
+        builder.HasKey(history => history.Id);
+
+        builder.Property(history => history.ExpiredDate)
+            .IsRequired();
+
+        builder.Property(history => history.RemainingTickets)
+            .IsRequired();
+
+        builder.Property(history => history.RemainingMessages)
+            .IsRequired();
+
+        builder.HasOne(history => history.Package)
+            .WithMany(package => package.PackageHistories)
+            .HasForeignKey(history => history.PackageId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(history => history.Account)
+            .WithMany(account => account.PackageHistory)
+            .HasForeignKey(history => history.AccountId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/Permission/PermissionConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/Permission/PermissionConfiguration.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.Permission;
+
+public class PermissionConfiguration : IEntityTypeConfiguration<Permission>
+{
+    public void Configure(EntityTypeBuilder<Permission> builder)
+    {
+        builder.HasKey(permission => permission.Id);
+
+        builder.Property(permission => permission.Title)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(permission => permission.Description)
+            .HasMaxLength(500);
+
+        builder.HasIndex(permission => permission.Title)
+            .IsUnique();
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/PermissionsRole/PermissionsRoleConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/PermissionsRole/PermissionsRoleConfiguration.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.PermissionsRole;
+
+public class PermissionsRoleConfiguration : IEntityTypeConfiguration<PermissionsRole>
+{
+    public void Configure(EntityTypeBuilder<PermissionsRole> builder)
+    {
+        builder.HasKey(permissionsRole => permissionsRole.Id);
+
+        builder.HasOne(permissionsRole => permissionsRole.Role)
+            .WithMany(role => role.RolePermissions)
+            .HasForeignKey(permissionsRole => permissionsRole.RoleId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(permissionsRole => permissionsRole.Permission)
+            .WithMany(permission => permission.PermissionsRoles)
+            .HasForeignKey(permissionsRole => permissionsRole.PermissionId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/QuestionFAQ/QuestionFAQConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/QuestionFAQ/QuestionFAQConfiguration.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.QuestionFAQ;
+
+public class QuestionFAQConfiguration : IEntityTypeConfiguration<QuestionFAQ>
+{
+    public void Configure(EntityTypeBuilder<QuestionFAQ> builder)
+    {
+        builder.HasKey(question => question.Id);
+
+        builder.Property(question => question.QuestionText)
+            .IsRequired()
+            .HasMaxLength(2000);
+
+        builder.Property(question => question.AnswerText)
+            .IsRequired()
+            .HasMaxLength(5000);
+
+        builder.Property(question => question.IsActive)
+            .IsRequired();
+
+        builder.HasOne(question => question.Category)
+            .WithMany(category => category.Questions)
+            .HasForeignKey(question => question.CategoryId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/RefreshToken/RefreshTokenConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/RefreshToken/RefreshTokenConfiguration.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.RefreshToken;
+
+public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
+{
+    public void Configure(EntityTypeBuilder<RefreshToken> builder)
+    {
+        builder.HasKey(token => token.Id);
+
+        builder.Property(token => token.Token)
+            .IsRequired();
+
+        builder.Property(token => token.ExpiresAt)
+            .IsRequired();
+
+        builder.HasOne(token => token.Account)
+            .WithMany(account => account.RefreshTokens)
+            .HasForeignKey(token => token.AccountId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/Role/RoleConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/Role/RoleConfiguration.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.Role;
+
+public class RoleConfiguration : IEntityTypeConfiguration<Role>
+{
+    public void Configure(EntityTypeBuilder<Role> builder)
+    {
+        builder.HasKey(role => role.Id);
+
+        builder.Property(role => role.Title)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.HasIndex(role => role.Title)
+            .IsUnique();
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/Ticket/TicketConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/Ticket/TicketConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.Ticket;
+
+public class TicketConfiguration : IEntityTypeConfiguration<Ticket>
+{
+    public void Configure(EntityTypeBuilder<Ticket> builder)
+    {
+        builder.HasKey(ticket => ticket.Id);
+
+        builder.Property(ticket => ticket.Topic)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.HasOne(ticket => ticket.Status)
+            .WithMany()
+            .HasForeignKey(ticket => ticket.StatusId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(ticket => ticket.Account)
+            .WithMany()
+            .HasForeignKey(ticket => ticket.AccountId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(ticket => ticket.Package)
+            .WithMany()
+            .HasForeignKey(ticket => ticket.PackageId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/UserCourseHistory/UserCourseHistoryConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/UserCourseHistory/UserCourseHistoryConfiguration.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.UserCourseHistory;
+
+public class UserCourseHistoryConfiguration : IEntityTypeConfiguration<UserCourseHistory>
+{
+    public void Configure(EntityTypeBuilder<UserCourseHistory> builder)
+    {
+        builder.HasKey(history => history.Id);
+
+        builder.HasOne(history => history.Course)
+            .WithMany(course => course.UserCourseHistory)
+            .HasForeignKey(history => history.CourseId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(history => history.Account)
+            .WithMany(account => account.UserCourseHistory)
+            .HasForeignKey(history => history.AccountId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/MTA.Infrastructure/Data/Configurations/UserProfile/UserProfileConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/UserProfile/UserProfileConfiguration.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MTA.Domain.Entities;
+
+namespace MTA.Infrastructure.Data.Configurations.UserProfile;
+
+public class UserProfileConfiguration : IEntityTypeConfiguration<UserProfile>
+{
+    public void Configure(EntityTypeBuilder<UserProfile> builder)
+    {
+        builder.HasKey(profile => profile.Id);
+
+        builder.Property(profile => profile.FirstName)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(profile => profile.LastName)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(profile => profile.DateOfBirth)
+            .IsRequired();
+
+        builder.Property(profile => profile.Experience)
+            .IsRequired();
+
+        builder.HasOne(profile => profile.Account)
+            .WithOne(account => account.UserProfile)
+            .HasForeignKey<UserProfile>(profile => profile.AccountId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(profile => profile.SkillLevel)
+            .WithMany()
+            .HasForeignKey(profile => profile.SkillLevelId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}


### PR DESCRIPTION
## Summary
- extract individual entity configuration logic from `ApplicationDbContext` into dedicated `IEntityTypeConfiguration` classes grouped per model
- update `ApplicationDbContext` to load all configurations from the assembly for a cleaner OnModelCreating implementation

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fb380644c083208d3dbf84c929a513