### PR TITLE
Record purchase prices for package and course histories

### DIFF
--- a/MTA.Application/DTOs/PackageHistoryDto.cs
+++ b/MTA.Application/DTOs/PackageHistoryDto.cs
@@ -31,7 +31,7 @@ public class PackageHistoryDto : BaseDto
     public string? PackageTitle { get; set; }
     
     /// <summary>
-    /// Package price
+    /// Price that the user paid when purchasing the package
     /// </summary>
     public decimal PackagePrice { get; set; }
     
@@ -72,7 +72,7 @@ public class PackageHistoryDto : BaseDto
 }
 
 
-public class CreatePackageHistoryDto 
+public class CreatePackageHistoryDto
 {
        /// <summary>
     /// Package ID
@@ -83,6 +83,11 @@ public class CreatePackageHistoryDto
     /// Account ID
     /// </summary>
     public int AccountId { get; set; }
+
+    /// <summary>
+    /// Price paid for the package (if omitted the current package price will be used)
+    /// </summary>
+    public decimal? PurchasePrice { get; set; }
 
     /// <summary>
     /// Whether the package is expired

--- a/MTA.Application/DTOs/PackageHistoryDto.cs
+++ b/MTA.Application/DTOs/PackageHistoryDto.cs
@@ -74,7 +74,7 @@ public class PackageHistoryDto : BaseDto
 
 public class CreatePackageHistoryDto
 {
-       /// <summary>
+    /// <summary>
     /// Package ID
     /// </summary>
     public int PackageId { get; set; }
@@ -85,12 +85,8 @@ public class CreatePackageHistoryDto
     public int AccountId { get; set; }
 
     /// <summary>
-    /// Price paid for the package (if omitted the current package price will be used)
-    /// </summary>
-    public decimal? PurchasePrice { get; set; }
-
-    /// <summary>
     /// Whether the package is expired
     /// </summary>
     public bool IsExpired { get; set; }
 }
+

--- a/MTA.Application/DTOs/UserCourseHistoryDto.cs
+++ b/MTA.Application/DTOs/UserCourseHistoryDto.cs
@@ -14,6 +14,11 @@ public class CreateUserCourseHistoryDto
     /// Account ID
     /// </summary>
     public int AccountId { get; set; }
+
+    /// <summary>
+    /// Price paid for the course (if omitted the current course price will be used)
+    /// </summary>
+    public decimal? PurchasePrice { get; set; }
 }
 
 public class UpdateUserCourseHistoryDto
@@ -33,6 +38,11 @@ public class UpdateUserCourseHistoryDto
     /// وضعیت دوره برای کاربر (اختیاری)
     /// </summary>
     public int StatusId { get; set; }
+
+    /// <summary>
+    /// Price that the user paid when enrolling in the course
+    /// </summary>
+    public decimal? PurchasePrice { get; set; }
 }
 
 

--- a/MTA.Application/DTOs/UserCourseHistoryDto.cs
+++ b/MTA.Application/DTOs/UserCourseHistoryDto.cs
@@ -15,10 +15,6 @@ public class CreateUserCourseHistoryDto
     /// </summary>
     public int AccountId { get; set; }
 
-    /// <summary>
-    /// Price paid for the course (if omitted the current course price will be used)
-    /// </summary>
-    public decimal? PurchasePrice { get; set; }
 }
 
 public class UpdateUserCourseHistoryDto

--- a/MTA.Application/Mapping/HistoryMappingProfile.cs
+++ b/MTA.Application/Mapping/HistoryMappingProfile.cs
@@ -30,11 +30,6 @@ public class HistoryMappingProfile : BaseMappingProfile
         CreateMap<UpdateUserCourseHistoryDto, UserCourseHistory>()
             .ForMember(dest => dest.AccountId, opt => opt.MapFrom(src => src.AccountId))
             .ForMember(dest => dest.CourseId, opt => opt.MapFrom(src => src.CourseId))
-            .ForMember(dest => dest.PurchasePrice, opt =>
-            {
-                opt.PreCondition(src => src.PurchasePrice.HasValue);
-                opt.MapFrom(src => src.PurchasePrice!.Value);
-            })
             .ForMember(dest => dest.Account, opt => opt.Ignore())
             .ForMember(dest => dest.Course, opt => opt.Ignore());
     }

--- a/MTA.Application/Mapping/HistoryMappingProfile.cs
+++ b/MTA.Application/Mapping/HistoryMappingProfile.cs
@@ -16,6 +16,7 @@ public class HistoryMappingProfile : BaseMappingProfile
             .ForMember(dest => dest.Id, opt => opt.Ignore())
             .ForMember(dest => dest.EnrolledAt, opt => opt.Ignore())
             .ForMember(dest => dest.StatusId, opt => opt.Ignore())
+            .ForMember(dest => dest.PurchasePrice, opt => opt.Ignore())
             .ForMember(dest => dest.Account, opt => opt.Ignore())
             .ForMember(dest => dest.Course, opt => opt.Ignore());
 
@@ -23,11 +24,17 @@ public class HistoryMappingProfile : BaseMappingProfile
         CreateMap<UserCourseHistory, UpdateUserCourseHistoryDto>()
             .ForMember(dest => dest.CourseId, opt => opt.MapFrom(src => src.CourseId))
             .ForMember(dest => dest.AccountId, opt => opt.MapFrom(src => src.AccountId))
-            .ForMember(dest => dest.StatusId, opt => opt.MapFrom(src => src.StatusId));
+            .ForMember(dest => dest.StatusId, opt => opt.MapFrom(src => src.StatusId))
+            .ForMember(dest => dest.PurchasePrice, opt => opt.MapFrom(src => src.PurchasePrice));
 
         CreateMap<UpdateUserCourseHistoryDto, UserCourseHistory>()
             .ForMember(dest => dest.AccountId, opt => opt.MapFrom(src => src.AccountId))
             .ForMember(dest => dest.CourseId, opt => opt.MapFrom(src => src.CourseId))
+            .ForMember(dest => dest.PurchasePrice, opt =>
+            {
+                opt.PreCondition(src => src.PurchasePrice.HasValue);
+                opt.MapFrom(src => src.PurchasePrice!.Value);
+            })
             .ForMember(dest => dest.Account, opt => opt.Ignore())
             .ForMember(dest => dest.Course, opt => opt.Ignore());
     }

--- a/MTA.Application/Mapping/PackageHistoryMappingProfile.cs
+++ b/MTA.Application/Mapping/PackageHistoryMappingProfile.cs
@@ -19,7 +19,7 @@ public class PackageHistoryMappingProfile : BaseMappingProfile
             .ForMember(dest => dest.RemainingMessages, opt => opt.MapFrom(src => src.RemainingMessages))
             .ForMember(dest => dest.PackageId, opt => opt.MapFrom(src => src.PackageId))
             .ForMember(dest => dest.PackageTitle, opt => opt.MapFrom(src => src.Package != null ? src.Package.Title : null))
-            .ForMember(dest => dest.PackagePrice, opt => opt.MapFrom(src => src.Package != null ? src.Package.Price : 0))
+            .ForMember(dest => dest.PackagePrice, opt => opt.MapFrom(src => src.PurchasePrice))
             .ForMember(dest => dest.TotalTickets, opt => opt.MapFrom(src => src.Package != null ? src.Package.TicketCount : 0))
             .ForMember(dest => dest.TotalMessages, opt => opt.MapFrom(src => src.Package != null ? src.Package.MessageCount : 0))
             .ForMember(dest => dest.AccountId, opt => opt.MapFrom(src => src.AccountId))
@@ -38,6 +38,7 @@ public class PackageHistoryMappingProfile : BaseMappingProfile
             .ForMember(dest => dest.RemainingMessages, opt => opt.MapFrom(src => src.RemainingMessages))
             .ForMember(dest => dest.PackageId, opt => opt.MapFrom(src => src.PackageId))
             .ForMember(dest => dest.AccountId, opt => opt.MapFrom(src => src.AccountId))
+            .ForMember(dest => dest.PurchasePrice, opt => opt.MapFrom(src => src.PackagePrice))
             .ForMember(dest => dest.CreatedAt, opt => opt.MapFrom(src => src.CreatedAt))
             .ForMember(dest => dest.UpdatedAt, opt => opt.MapFrom(src => src.UpdatedAt))
             .ForMember(dest => dest.Package, opt => opt.Ignore())
@@ -48,12 +49,13 @@ public class PackageHistoryMappingProfile : BaseMappingProfile
             .ForMember(dest => dest.ExpiredDate, opt => opt.Ignore()) // مقداردهی دستی در Service
             .ForMember(dest => dest.RemainingTickets, opt => opt.Ignore())
             .ForMember(dest => dest.RemainingMessages, opt => opt.Ignore())
+            .ForMember(dest => dest.PurchasePrice, opt => opt.Ignore())
             .ForMember(dest => dest.Package, opt => opt.Ignore())
             .ForMember(dest => dest.Account, opt => opt.Ignore());
 
         CreateMap<PackageHistory, PackageHistoryDto>()
             .ForMember(dest => dest.PackageTitle, opt => opt.MapFrom(src => src.Package.Title))
-            .ForMember(dest => dest.PackagePrice, opt => opt.MapFrom(src => src.Package.Price))
+            .ForMember(dest => dest.PackagePrice, opt => opt.MapFrom(src => src.PurchasePrice))
             .ForMember(dest => dest.UserFirstName, opt => opt.MapFrom(src => src.Account.UserProfile.FirstName))
             .ForMember(dest => dest.UserLastName, opt => opt.MapFrom(src => src.Account.UserProfile.LastName))
             .ForMember(dest => dest.UserEmail, opt => opt.MapFrom(src => src.Account.Email))

--- a/MTA.Application/Mapping/PackageMappingProfile.cs
+++ b/MTA.Application/Mapping/PackageMappingProfile.cs
@@ -46,7 +46,7 @@ public class PackageMappingProfile : BaseMappingProfile
             .ForMember(dest => dest.RemainingTickets, opt => opt.MapFrom(src => src.RemainingTickets))
             .ForMember(dest => dest.RemainingMessages, opt => opt.MapFrom(src => src.RemainingMessages))
             .ForMember(dest => dest.PackageTitle, opt => opt.MapFrom(src => src.Package.Title))
-            .ForMember(dest => dest.PackagePrice, opt => opt.MapFrom(src => src.Package.Price))
+            .ForMember(dest => dest.PackagePrice, opt => opt.MapFrom(src => src.PurchasePrice))
             .ForMember(dest => dest.TotalTickets, opt => opt.MapFrom(src => src.Package.TicketCount))
             .ForMember(dest => dest.TotalMessages, opt => opt.MapFrom(src => src.Package.MessageCount))
             .ForMember(dest => dest.UserFirstName, opt => opt.MapFrom(src => src.Account.UserProfile.FirstName))
@@ -61,6 +61,7 @@ public class PackageMappingProfile : BaseMappingProfile
             .ForMember(dest => dest.ExpiredDate, opt => opt.MapFrom(src => src.ExpiredDate))
             .ForMember(dest => dest.RemainingTickets, opt => opt.MapFrom(src => src.RemainingTickets))
             .ForMember(dest => dest.RemainingMessages, opt => opt.MapFrom(src => src.RemainingMessages))
+            .ForMember(dest => dest.PurchasePrice, opt => opt.MapFrom(src => src.PackagePrice))
             .ForMember(dest => dest.Account, opt => opt.Ignore())
             .ForMember(dest => dest.Package, opt => opt.Ignore());
     }

--- a/MTA.Application/Services/Service/PackageHistoryService.cs
+++ b/MTA.Application/Services/Service/PackageHistoryService.cs
@@ -176,7 +176,7 @@ public class PackageHistoryService : IPackageHistoryService
             ExpiredDate = DateTime.UtcNow.AddMonths(package.Duration), // مثال: Duration ماه
             RemainingTickets = package.TicketCount,
             RemainingMessages = package.MessageCount,
-            PurchasePrice = dto.PurchasePrice ?? package.Price
+            PurchasePrice = package.Price
         };
 
         // ذخیره در دیتابیس

--- a/MTA.Application/Services/Service/PackageHistoryService.cs
+++ b/MTA.Application/Services/Service/PackageHistoryService.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using MTA.Application.DTOs;
 using MTA.Domain.Entities;
 using MTA.Domain.Interfaces;
+using System.Collections.Generic;
 
 namespace MTA.Application.Services;
 
@@ -174,7 +175,8 @@ public class PackageHistoryService : IPackageHistoryService
             CreatedAt = DateTime.UtcNow,
             ExpiredDate = DateTime.UtcNow.AddMonths(package.Duration), // مثال: Duration ماه
             RemainingTickets = package.TicketCount,
-            RemainingMessages = package.MessageCount
+            RemainingMessages = package.MessageCount,
+            PurchasePrice = dto.PurchasePrice ?? package.Price
         };
 
         // ذخیره در دیتابیس
@@ -187,7 +189,7 @@ public class PackageHistoryService : IPackageHistoryService
             Id = created.Id,
             PackageId = package.Id,
             PackageTitle = package.Title,
-            PackagePrice = package.Price,
+            PackagePrice = packageHistory.PurchasePrice,
             RemainingTickets = created.RemainingTickets,
             RemainingMessages = created.RemainingMessages,
             ExpiredDate = created.ExpiredDate,
@@ -217,6 +219,7 @@ public class PackageHistoryService : IPackageHistoryService
         existingPackageHistory.RemainingMessages = packageHistoryDto.RemainingMessages;
         existingPackageHistory.PackageId = packageHistoryDto.PackageId;
         existingPackageHistory.AccountId = packageHistoryDto.AccountId;
+        existingPackageHistory.PurchasePrice = packageHistoryDto.PackagePrice;
         existingPackageHistory.UpdatedAt = DateTime.UtcNow;
 
         var updatedPackageHistory = await _unitOfWork.Repository<PackageHistory>().UpdateAsync(existingPackageHistory);

--- a/MTA.Application/Services/Service/UserCourseHistoryService.cs
+++ b/MTA.Application/Services/Service/UserCourseHistoryService.cs
@@ -175,7 +175,7 @@ public class UserCourseHistoryService : IUserCourseHistoryService
                 CourseId = userCourseHistoryDto.CourseId,
                 EnrolledAt = DateTime.UtcNow,
                 StatusId = activeStatusLookup.Id, // مقدار پویا
-                PurchasePrice = userCourseHistoryDto.PurchasePrice ?? course.Price
+                PurchasePrice = course.Price
             };
 
             var created = await _unitOfWork.Repository<UserCourseHistory>().AddAsync(userCourseHistory);
@@ -203,8 +203,6 @@ public class UserCourseHistoryService : IUserCourseHistoryService
             // Update properties
             existing.CourseId = userCourseHistoryDto.CourseId;
             existing.AccountId = userCourseHistoryDto.AccountId;
-            if (userCourseHistoryDto.PurchasePrice.HasValue)
-                existing.PurchasePrice = userCourseHistoryDto.PurchasePrice.Value;
             existing.UpdatedAt = DateTime.UtcNow;
 
             var updated = await _unitOfWork.Repository<UserCourseHistory>().UpdateAsync(existing);

--- a/MTA.Application/Services/Service/UserCourseHistoryService.cs
+++ b/MTA.Application/Services/Service/UserCourseHistoryService.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using AutoMapper;
 using Microsoft.Extensions.Logging;
 using MTA.Domain.Interfaces;
+using System.Collections.Generic;
 
 namespace MTA.Application.Services;
 
@@ -160,6 +161,9 @@ public class UserCourseHistoryService : IUserCourseHistoryService
             if (existing)
                 throw new InvalidOperationException("User has already purchased this course");
 
+            var course = await _unitOfWork.Repository<Course>().GetByIdAsync(userCourseHistoryDto.CourseId)
+                ?? throw new KeyNotFoundException("Course not found");
+
             // دریافت StatusId از جدول Lookups
             var activeStatusLookup = await _lookupService.GetByCategoryAndKeyAsync("UserCourseStatus", "Active");
             if (activeStatusLookup == null)
@@ -170,7 +174,8 @@ public class UserCourseHistoryService : IUserCourseHistoryService
                 AccountId = userCourseHistoryDto.AccountId,
                 CourseId = userCourseHistoryDto.CourseId,
                 EnrolledAt = DateTime.UtcNow,
-                StatusId = activeStatusLookup.Id // مقدار پویا
+                StatusId = activeStatusLookup.Id, // مقدار پویا
+                PurchasePrice = userCourseHistoryDto.PurchasePrice ?? course.Price
             };
 
             var created = await _unitOfWork.Repository<UserCourseHistory>().AddAsync(userCourseHistory);
@@ -198,6 +203,8 @@ public class UserCourseHistoryService : IUserCourseHistoryService
             // Update properties
             existing.CourseId = userCourseHistoryDto.CourseId;
             existing.AccountId = userCourseHistoryDto.AccountId;
+            if (userCourseHistoryDto.PurchasePrice.HasValue)
+                existing.PurchasePrice = userCourseHistoryDto.PurchasePrice.Value;
             existing.UpdatedAt = DateTime.UtcNow;
 
             var updated = await _unitOfWork.Repository<UserCourseHistory>().UpdateAsync(existing);

--- a/MTA.Domain/Entities/HistoryPackage.cs
+++ b/MTA.Domain/Entities/HistoryPackage.cs
@@ -10,6 +10,7 @@ public class PackageHistory : BaseEntity
     public DateTime ExpiredDate { get; set; }
     public int RemainingTickets { get; set; }
     public int RemainingMessages { get; set; }
+    public decimal PurchasePrice { get; set; }
 
     public int PackageId { get; set; }
     [ForeignKey("PackageId")]

--- a/MTA.Domain/Entities/HistoryUserCourse.cs
+++ b/MTA.Domain/Entities/HistoryUserCourse.cs
@@ -7,11 +7,13 @@ namespace MTA.Domain.Entities;
 /// </summary>
 public class UserCourseHistory : BaseEntity
 {
-    
+
     public int CourseId { get; set; }
     [ForeignKey("CourseId")]
     public virtual Course Course { get; set; } = null!;
-    
+
+    public decimal PurchasePrice { get; set; }
+
 
     public int AccountId { get; set; }
     [ForeignKey("AccountId")]

--- a/MTA.Infrastructure/Data/Configurations/PackageHistory/PackageHistoryConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/PackageHistory/PackageHistoryConfiguration.cs
@@ -19,6 +19,10 @@ public class PackageHistoryConfiguration : IEntityTypeConfiguration<PackageHisto
         builder.Property(history => history.RemainingMessages)
             .IsRequired();
 
+        builder.Property(history => history.PurchasePrice)
+            .HasColumnType("decimal(18,2)")
+            .IsRequired();
+
         builder.HasOne(history => history.Package)
             .WithMany(package => package.PackageHistories)
             .HasForeignKey(history => history.PackageId)

--- a/MTA.Infrastructure/Data/Configurations/UserCourseHistory/UserCourseHistoryConfiguration.cs
+++ b/MTA.Infrastructure/Data/Configurations/UserCourseHistory/UserCourseHistoryConfiguration.cs
@@ -19,5 +19,9 @@ public class UserCourseHistoryConfiguration : IEntityTypeConfiguration<UserCours
             .WithMany(account => account.UserCourseHistory)
             .HasForeignKey(history => history.AccountId)
             .OnDelete(DeleteBehavior.Restrict);
+
+        builder.Property(history => history.PurchasePrice)
+            .HasColumnType("decimal(18,2)")
+            .IsRequired();
     }
 }

--- a/MTA.Infrastructure/Migrations/20251116000000_AddPurchasePriceToHistories.cs
+++ b/MTA.Infrastructure/Migrations/20251116000000_AddPurchasePriceToHistories.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MTA.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPurchasePriceToHistories : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "PurchasePrice",
+                table: "UserCourseHistories",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "PurchasePrice",
+                table: "PackageHistories",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PurchasePrice",
+                table: "UserCourseHistories");
+
+            migrationBuilder.DropColumn(
+                name: "PurchasePrice",
+                table: "PackageHistories");
+        }
+    }
+}

--- a/MTA.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/MTA.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -450,6 +450,9 @@ namespace MTA.Infrastructure.Migrations
                     b.Property<int>("RemainingTickets")
                         .HasColumnType("int");
 
+                    b.Property<decimal>("PurchasePrice")
+                        .HasColumnType("decimal(18,2)");
+
                     b.Property<DateTime>("UpdatedAt")
                         .HasColumnType("datetime2");
 
@@ -688,6 +691,9 @@ namespace MTA.Infrastructure.Migrations
 
                     b.Property<DateTime>("EnrolledAt")
                         .HasColumnType("datetime2");
+
+                    b.Property<decimal>("PurchasePrice")
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<int>("StatusId")
                         .HasColumnType("int");


### PR DESCRIPTION
## Summary
- persist the purchase price on package and user course history entities and DTOs so the original price is retained
- update history mapping profiles and services to populate the recorded purchase price when creating or updating histories
- add an EF Core migration and configuration updates to add the PurchasePrice columns to the database schema

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68fb497bd52c83208f9e98ea374ffdb2