### PR TITLE
Include related data in package history pagination

### DIFF
--- a/MTA.Application/Services/Service/PackageHistoryService.cs
+++ b/MTA.Application/Services/Service/PackageHistoryService.cs
@@ -26,7 +26,10 @@ public class PackageHistoryService : IPackageHistoryService
     /// </summary>
     public async Task<PaginatedResult<PackageHistoryDto>> GetAllAsync(int page = 1, int pageSize = 10, int? accountId = null, int? packageId = null, bool? isExpired = null)
     {
-        var query = _unitOfWork.Repository<PackageHistory>().GetQueryable();
+        var query = _unitOfWork
+            .Repository<PackageHistory>()
+            .GetQueryable()
+            .AsNoTracking();
 
         // Apply filters
         if (accountId.HasValue)
@@ -55,8 +58,13 @@ public class PackageHistoryService : IPackageHistoryService
         // Get total count
         var totalCount = await _unitOfWork.Repository<PackageHistory>().CountAsync(query);
 
+        var dataQuery = query
+            .Include(ph => ph.Package)
+            .Include(ph => ph.Account)
+            .ThenInclude(account => account.UserProfile);
+
         // Apply pagination
-        var packageHistories = await _unitOfWork.Repository<PackageHistory>().GetPagedAsync(query, page, pageSize);
+        var packageHistories = await _unitOfWork.Repository<PackageHistory>().GetPagedAsync(dataQuery, page, pageSize);
 
         // Map to DTOs with additional data
         var packageHistoryDtos = packageHistories.Select(ph => _mapper.Map<PackageHistoryDto>(ph)).ToList();


### PR DESCRIPTION
## Summary
- load package, account, and user profile relations when retrieving paginated package histories so buyer and package metadata are available to the API consumers

## Testing
- dotnet test *(fails: `dotnet`: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fe4f86ee948320a9c4d3c94ca0a43d