### PR TITLE
Restrict FAQ question update inputs to editable fields

### DIFF
--- a/MTA.Application/DTOs/QuestionDto.cs
+++ b/MTA.Application/DTOs/QuestionDto.cs
@@ -19,7 +19,7 @@ public class QuestionDto : BaseDto
     public string? CategoryTitle { get; set; }
 }
 
-public class CreateQuestionDto 
+public class CreateQuestionDto
 {
     /// <summary>
     /// The question text
@@ -33,5 +33,23 @@ public class CreateQuestionDto
     public bool IsActive { get; set; }
     public int CategoryId { get; set; }
     public string? CategoryTitle { get; set; }
+}
+
+public class UpdateQuestionDto
+{
+    /// <summary>
+    /// The question text
+    /// </summary>
+    public required string QuestionText { get; set; }
+
+    /// <summary>
+    /// The answer text
+    /// </summary>
+    public required string AnswerText { get; set; }
+
+    /// <summary>
+    /// Indicates whether the question is active
+    /// </summary>
+    public bool IsActive { get; set; }
 }
 

--- a/MTA.Application/Services/Interface/IFAQService.cs
+++ b/MTA.Application/Services/Interface/IFAQService.cs
@@ -83,7 +83,7 @@ public interface IFAQService
     /// <param name="id">Question ID</param>
     /// <param name="questionDto">Updated question data</param>
     /// <returns>Updated question</returns>
-    Task<QuestionDto> UpdateQuestionAsync(int id, QuestionDto questionDto);
+    Task<QuestionDto> UpdateQuestionAsync(int id, UpdateQuestionDto questionDto);
     
     /// <summary>
     /// Delete question

--- a/MTA.Application/Services/Service/FAQService.cs
+++ b/MTA.Application/Services/Service/FAQService.cs
@@ -198,19 +198,21 @@ public class FAQService : IFAQService
         return result;
     }
 
-    public async Task<QuestionDto> UpdateQuestionAsync(int id, QuestionDto questionDto)
+    public async Task<QuestionDto> UpdateQuestionAsync(int id, UpdateQuestionDto questionDto)
     {
         var existingQuestion = await _unitOfWork.Repository<QuestionFAQ>().GetByIdAsync(id);
         if (existingQuestion == null)
             throw new ArgumentException($"Question with ID {id} not found");
 
-        _mapper.Map(questionDto, existingQuestion);
+        existingQuestion.QuestionText = questionDto.QuestionText;
+        existingQuestion.AnswerText = questionDto.AnswerText;
+        existingQuestion.IsActive = questionDto.IsActive;
         existingQuestion.UpdatedAt = DateTime.UtcNow;
-        
-        _unitOfWork.Repository<QuestionFAQ>().UpdateAsync(existingQuestion);
+
+        await _unitOfWork.Repository<QuestionFAQ>().UpdateAsync(existingQuestion);
         await _unitOfWork.SaveChangesAsync();
-        
-        return await GetQuestionByIdAsync(id) ?? questionDto;
+
+        return await GetQuestionByIdAsync(id) ?? _mapper.Map<QuestionDto>(existingQuestion);
     }
 
     public async Task<bool> DeleteQuestionAsync(int id)

--- a/MTA.Web/Controllers/FAQController.cs
+++ b/MTA.Web/Controllers/FAQController.cs
@@ -352,7 +352,7 @@ public class FAQController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<QuestionDto>> UpdateQuestion(int id, [FromBody] QuestionDto questionDto)
+    public async Task<ActionResult<QuestionDto>> UpdateQuestion(int id, [FromBody] UpdateQuestionDto questionDto)
     {
         try
         {


### PR DESCRIPTION
## Summary
- introduce UpdateQuestionDto so updates only accept question text, answer text, and active flag
- adjust FAQ service and controller to use the new DTO without touching category metadata

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fe51d4d0ac832097ac7d261c2914bb