### PR TITLE
Limit user course history detail DTO usage to read endpoints

### DIFF
--- a/MTA.Application/DTOs/UserCourseHistoryDto.cs
+++ b/MTA.Application/DTOs/UserCourseHistoryDto.cs
@@ -17,6 +17,47 @@ public class CreateUserCourseHistoryDto
 
 }
 
+/// <summary>
+/// Detailed representation of a course purchase made by a user
+/// </summary>
+public class UserCourseHistoryDetailDto : BaseDto
+{
+    /// <summary>
+    /// Course ID
+    /// </summary>
+    public int CourseId { get; set; }
+
+    /// <summary>
+    /// Course title
+    /// </summary>
+    public string? CourseTitle { get; set; }
+
+    /// <summary>
+    /// Account ID of the purchaser
+    /// </summary>
+    public int AccountId { get; set; }
+
+    /// <summary>
+    /// First name of the purchaser
+    /// </summary>
+    public string? UserFirstName { get; set; }
+
+    /// <summary>
+    /// Last name of the purchaser
+    /// </summary>
+    public string? UserLastName { get; set; }
+
+    /// <summary>
+    /// Date when the course was purchased
+    /// </summary>
+    public DateTime PurchasedAt { get; set; }
+
+    /// <summary>
+    /// Price that the user paid when enrolling in the course
+    /// </summary>
+    public decimal? PurchasePrice { get; set; }
+}
+
 public class UpdateUserCourseHistoryDto
 {
     public int Id { get; set; }

--- a/MTA.Application/Mapping/HistoryMappingProfile.cs
+++ b/MTA.Application/Mapping/HistoryMappingProfile.cs
@@ -27,6 +27,15 @@ public class HistoryMappingProfile : BaseMappingProfile
             .ForMember(dest => dest.StatusId, opt => opt.MapFrom(src => src.StatusId))
             .ForMember(dest => dest.PurchasePrice, opt => opt.MapFrom(src => src.PurchasePrice));
 
+        CreateMap<UserCourseHistory, UserCourseHistoryDetailDto>()
+            .ForMember(dest => dest.CourseTitle, opt => opt.MapFrom(src => src.Course != null ? src.Course.Title : null))
+            .ForMember(dest => dest.UserFirstName, opt => opt.MapFrom(src =>
+                src.Account != null && src.Account.UserProfile != null ? src.Account.UserProfile.FirstName : null))
+            .ForMember(dest => dest.UserLastName, opt => opt.MapFrom(src =>
+                src.Account != null && src.Account.UserProfile != null ? src.Account.UserProfile.LastName : null))
+            .ForMember(dest => dest.PurchasedAt, opt => opt.MapFrom(src => src.EnrolledAt))
+            .ForMember(dest => dest.PurchasePrice, opt => opt.MapFrom(src => src.PurchasePrice));
+
         CreateMap<UpdateUserCourseHistoryDto, UserCourseHistory>()
             .ForMember(dest => dest.AccountId, opt => opt.MapFrom(src => src.AccountId))
             .ForMember(dest => dest.CourseId, opt => opt.MapFrom(src => src.CourseId))

--- a/MTA.Application/Services/Interface/IUserCourseHistoryService.cs
+++ b/MTA.Application/Services/Interface/IUserCourseHistoryService.cs
@@ -15,28 +15,28 @@ public interface IUserCourseHistoryService
     /// <param name="accountId">Filter by account ID</param>
     /// <param name="courseId">Filter by course ID</param>
     /// <returns>Paginated list of user course histories</returns>
-    Task<PaginatedResult<UpdateUserCourseHistoryDto>> GetAllAsync(int page = 1, int pageSize = 10, int? accountId = null, int? courseId = null);
+    Task<PaginatedResult<UserCourseHistoryDetailDto>> GetAllAsync(int page = 1, int pageSize = 10, int? accountId = null, int? courseId = null);
     
     /// <summary>
     /// Get user course history by ID
     /// </summary>
     /// <param name="id">User course history ID</param>
     /// <returns>User course history details</returns>
-    Task<UpdateUserCourseHistoryDto?> GetByIdAsync(int id);
+    Task<UserCourseHistoryDetailDto?> GetByIdAsync(int id);
     
     /// <summary>
     /// Get user course histories by account ID
     /// </summary>
     /// <param name="accountId">Account ID</param>
     /// <returns>List of user course histories</returns>
-    Task<IEnumerable<UpdateUserCourseHistoryDto>> GetByAccountAsync(int accountId);
+    Task<IEnumerable<UserCourseHistoryDetailDto>> GetByAccountAsync(int accountId);
     
     /// <summary>
     /// Get user course histories by course ID
     /// </summary>
     /// <param name="courseId">Course ID</param>
     /// <returns>List of user course histories</returns>
-    Task<IEnumerable<UpdateUserCourseHistoryDto>> GetByCourseAsync(int courseId);
+    Task<IEnumerable<UserCourseHistoryDetailDto>> GetByCourseAsync(int courseId);
     
     /// <summary>
     /// Check if user has purchased course
@@ -80,7 +80,7 @@ public interface IUserCourseHistoryService
     /// <param name="startDate">Start date</param>
     /// <param name="endDate">End date</param>
     /// <returns>List of user course histories</returns>
-    Task<IEnumerable<UpdateUserCourseHistoryDto>> GetByDateRangeAsync(DateTime startDate, DateTime endDate);
+    Task<IEnumerable<UserCourseHistoryDetailDto>> GetByDateRangeAsync(DateTime startDate, DateTime endDate);
     
     ///// <summary>
     ///// Get popular courses (by purchase count)

--- a/MTA.Application/Services/Service/UserCourseHistoryService.cs
+++ b/MTA.Application/Services/Service/UserCourseHistoryService.cs
@@ -6,6 +6,7 @@ using AutoMapper;
 using Microsoft.Extensions.Logging;
 using MTA.Domain.Interfaces;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MTA.Application.Services;
 
@@ -27,7 +28,7 @@ public class UserCourseHistoryService : IUserCourseHistoryService
         _lookupService = lookupService;
     }
 
-    public async Task<PaginatedResult<UpdateUserCourseHistoryDto>> GetAllAsync(int page = 1, int pageSize = 10, int? accountId = null, int? courseId = null)
+    public async Task<PaginatedResult<UserCourseHistoryDetailDto>> GetAllAsync(int page = 1, int pageSize = 10, int? accountId = null, int? courseId = null)
     {
         try
         {
@@ -36,7 +37,7 @@ public class UserCourseHistoryService : IUserCourseHistoryService
                 .Include(uch => uch.Account)
                     .ThenInclude(acc => acc.UserProfile)
                 .Include(uch => uch.Status)
-                .AsQueryable();
+                .AsNoTracking();
 
             // Apply filters
             if (accountId.HasValue)
@@ -54,9 +55,9 @@ public class UserCourseHistoryService : IUserCourseHistoryService
                 .Take(pageSize)
                 .ToListAsync();
 
-            var dtos = _mapper.Map<IEnumerable<UpdateUserCourseHistoryDto>>(items);
+            var dtos = _mapper.Map<IEnumerable<UserCourseHistoryDetailDto>>(items);
 
-            return new PaginatedResult<UpdateUserCourseHistoryDto>
+            return new PaginatedResult<UserCourseHistoryDetailDto>
             {
                 Data = dtos,
                 TotalCount = totalCount,
@@ -71,7 +72,7 @@ public class UserCourseHistoryService : IUserCourseHistoryService
         }
     }
 
-    public async Task<UpdateUserCourseHistoryDto?> GetByIdAsync(int id)
+    public async Task<UserCourseHistoryDetailDto?> GetByIdAsync(int id)
     {
         try
         {
@@ -80,9 +81,10 @@ public class UserCourseHistoryService : IUserCourseHistoryService
                 .Include(uch => uch.Account)
                     .ThenInclude(acc => acc.UserProfile)
                 .Include(uch => uch.Status)
+                .AsNoTracking()
                 .FirstOrDefaultAsync(uch => uch.Id == id);
 
-            return userCourseHistory != null ? _mapper.Map<UpdateUserCourseHistoryDto>(userCourseHistory) : null;
+            return userCourseHistory != null ? _mapper.Map<UserCourseHistoryDetailDto>(userCourseHistory) : null;
         }
         catch (Exception ex)
         {
@@ -91,7 +93,7 @@ public class UserCourseHistoryService : IUserCourseHistoryService
         }
     }
 
-    public async Task<IEnumerable<UpdateUserCourseHistoryDto>> GetByAccountAsync(int accountId)
+    public async Task<IEnumerable<UserCourseHistoryDetailDto>> GetByAccountAsync(int accountId)
     {
         try
         {
@@ -102,9 +104,10 @@ public class UserCourseHistoryService : IUserCourseHistoryService
                 .Include(uch => uch.Status)
                 .Where(uch => uch.AccountId == accountId)
                 .OrderByDescending(uch => uch.EnrolledAt)
+                .AsNoTracking()
                 .ToListAsync();
 
-            return _mapper.Map<IEnumerable<UpdateUserCourseHistoryDto>>(userCourseHistories);
+            return _mapper.Map<IEnumerable<UserCourseHistoryDetailDto>>(userCourseHistories);
         }
         catch (Exception ex)
         {
@@ -113,7 +116,7 @@ public class UserCourseHistoryService : IUserCourseHistoryService
         }
     }
 
-    public async Task<IEnumerable<UpdateUserCourseHistoryDto>> GetByCourseAsync(int courseId)
+    public async Task<IEnumerable<UserCourseHistoryDetailDto>> GetByCourseAsync(int courseId)
     {
         try
         {
@@ -124,9 +127,10 @@ public class UserCourseHistoryService : IUserCourseHistoryService
                 .Include(uch => uch.Status)
                 .Where(uch => uch.CourseId == courseId)
                 .OrderByDescending(uch => uch.EnrolledAt)
+                .AsNoTracking()
                 .ToListAsync();
 
-            return _mapper.Map<IEnumerable<UpdateUserCourseHistoryDto>>(userCourseHistories);
+            return _mapper.Map<IEnumerable<UserCourseHistoryDetailDto>>(userCourseHistories);
         }
         catch (Exception ex)
         {
@@ -181,8 +185,7 @@ public class UserCourseHistoryService : IUserCourseHistoryService
             var created = await _unitOfWork.Repository<UserCourseHistory>().AddAsync(userCourseHistory);
             await _unitOfWork.SaveChangesAsync();
 
-            return await GetByIdAsync(created.Id) ??
-                   throw new InvalidOperationException("Failed to retrieve created user course history");
+            return _mapper.Map<UpdateUserCourseHistoryDto>(created);
         }
         catch (Exception ex)
         {
@@ -208,7 +211,7 @@ public class UserCourseHistoryService : IUserCourseHistoryService
             var updated = await _unitOfWork.Repository<UserCourseHistory>().UpdateAsync(existing);
             await _unitOfWork.SaveChangesAsync();
 
-            return await GetByIdAsync(updated.Id) ?? throw new InvalidOperationException("Failed to retrieve updated user course history");
+            return _mapper.Map<UpdateUserCourseHistoryDto>(updated);
         }
         catch (Exception ex)
         {
@@ -240,6 +243,7 @@ public class UserCourseHistoryService : IUserCourseHistoryService
         {
             var allUserCourseHistories = await _unitOfWork.Repository<UserCourseHistory>().GetQueryable()
                 .Include(uch => uch.Course)
+                .AsNoTracking()
                 .ToListAsync();
 
             var totalPurchases = allUserCourseHistories.Count;
@@ -279,7 +283,7 @@ public class UserCourseHistoryService : IUserCourseHistoryService
         }
     }
 
-    public async Task<IEnumerable<UpdateUserCourseHistoryDto>> GetByDateRangeAsync(DateTime startDate, DateTime endDate)
+    public async Task<IEnumerable<UserCourseHistoryDetailDto>> GetByDateRangeAsync(DateTime startDate, DateTime endDate)
     {
         try
         {
@@ -290,9 +294,10 @@ public class UserCourseHistoryService : IUserCourseHistoryService
                 .Include(uch => uch.Status)
                 .Where(uch => uch.EnrolledAt >= startDate && uch.EnrolledAt <= endDate)
                 .OrderByDescending(uch => uch.EnrolledAt)
+                .AsNoTracking()
                 .ToListAsync();
 
-            return _mapper.Map<IEnumerable<UpdateUserCourseHistoryDto>>(userCourseHistories);
+            return _mapper.Map<IEnumerable<UserCourseHistoryDetailDto>>(userCourseHistories);
         }
         catch (Exception ex)
         {

--- a/MTA.Web/Controllers/UserCourseHistoryController.cs
+++ b/MTA.Web/Controllers/UserCourseHistoryController.cs
@@ -38,7 +38,7 @@ public class UserCourseHistoryController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<PaginatedResult<UpdateUserCourseHistoryDto>>> GetUserCourseHistories(
+    public async Task<ActionResult<PaginatedResult<UserCourseHistoryDetailDto>>> GetUserCourseHistories(
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 10,
         [FromQuery] int? accountId = null,
@@ -67,7 +67,7 @@ public class UserCourseHistoryController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<UpdateUserCourseHistoryDto>> GetUserCourseHistory(int id)
+    public async Task<ActionResult<UserCourseHistoryDetailDto>> GetUserCourseHistory(int id)
     {
         try
         {
@@ -192,7 +192,7 @@ public class UserCourseHistoryController : ControllerBase
     [HttpGet("account/{accountId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<IEnumerable<UpdateUserCourseHistoryDto>>> GetUserCourseHistoriesByAccount(int accountId)
+    public async Task<ActionResult<IEnumerable<UserCourseHistoryDetailDto>>> GetUserCourseHistoriesByAccount(int accountId)
     {
         try
         {
@@ -215,7 +215,7 @@ public class UserCourseHistoryController : ControllerBase
     [HttpGet("course/{courseId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<IEnumerable<UpdateUserCourseHistoryDto>>> GetUserCourseHistoriesByCourse(int courseId)
+    public async Task<ActionResult<IEnumerable<UserCourseHistoryDetailDto>>> GetUserCourseHistoriesByCourse(int courseId)
     {
         try
         {


### PR DESCRIPTION
## Summary
- keep detailed purchaser information DTO limited to read-only user course history queries
- restore create and update service signatures to return their dedicated DTO and adjust controller actions accordingly

## Testing
- dotnet build *(fails: `dotnet` CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5e9abddc83208c2228b929727c3b