### PR TITLE
Expose user email in user search results

### DIFF
--- a/MTA.Application/DTOs/UserDto.cs
+++ b/MTA.Application/DTOs/UserDto.cs
@@ -11,6 +11,7 @@ namespace MTA.Application.DTOs.User
         public int Id { get; set; }
         public string FirstName { get; set; } = string.Empty;
         public string LastName { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
         public DateTime DateOfBirth { get; set; }
         public int Experience { get; set; }
         public int SkillLevelId { get; set; } = 1;

--- a/MTA.Application/Services/Service/UserProfileService.cs
+++ b/MTA.Application/Services/Service/UserProfileService.cs
@@ -120,6 +120,7 @@ public class UserProfileService : IUserProfileService
         int total = await query.CountAsync();
 
         var items = await query
+            .Include(u => u.Account)
             .Skip((queryDto.Page - 1) * queryDto.PageSize)
             .Take(queryDto.PageSize)
             .Select(u => new UserProfileDto
@@ -127,6 +128,7 @@ public class UserProfileService : IUserProfileService
                 Id = u.Id,
                 FirstName = u.FirstName,
                 LastName = u.LastName,
+                Email = u.Account.Email,
                 DateOfBirth = u.DateOfBirth,
                 Experience = u.Experience,
                 SkillLevelId = u.SkillLevelId,
@@ -298,6 +300,7 @@ public class UserProfileService : IUserProfileService
             Id = userProfile.Id,
             FirstName = userProfile.FirstName,
             LastName = userProfile.LastName,
+            Email = userProfile.Account?.Email ?? string.Empty,
             DateOfBirth = userProfile.DateOfBirth,
             Experience = userProfile.Experience,
             AccountId = userProfile.AccountId,


### PR DESCRIPTION
## Summary
- add an email field to `UserProfileDto`
- include the account email when mapping user profiles and when returning search results

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fe6ddda0208320ba8550bd23a06302