### PR TITLE
Add dashboard statistics endpoint

### DIFF
--- a/MTA.Application/DTOs/DashboardStatisticsDto.cs
+++ b/MTA.Application/DTOs/DashboardStatisticsDto.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MTA.Application.DTOs;
+
+/// <summary>
+/// Represents aggregated dashboard statistics for administrative insights.
+/// </summary>
+public class DashboardStatisticsDto
+{
+    /// <summary>
+    /// Total number of registered users.
+    /// </summary>
+    public int TotalUsers { get; set; }
+
+    /// <summary>
+    /// Total number of purchased courses.
+    /// </summary>
+    public int TotalCoursePurchases { get; set; }
+
+    /// <summary>
+    /// Total number of purchased packages.
+    /// </summary>
+    public int TotalPackagePurchases { get; set; }
+
+    /// <summary>
+    /// Total number of received support tickets.
+    /// </summary>
+    public int TotalTickets { get; set; }
+
+    /// <summary>
+    /// Users with the highest activity in purchasing packages.
+    /// </summary>
+    public IEnumerable<TopUserPurchaseDto> TopPackageBuyers { get; set; } = Enumerable.Empty<TopUserPurchaseDto>();
+
+    /// <summary>
+    /// Users with the highest activity in purchasing courses.
+    /// </summary>
+    public IEnumerable<TopUserPurchaseDto> TopCourseBuyers { get; set; } = Enumerable.Empty<TopUserPurchaseDto>();
+}
+
+/// <summary>
+/// Represents a single user's aggregated purchase information.
+/// </summary>
+public class TopUserPurchaseDto
+{
+    /// <summary>
+    /// Unique identifier of the account.
+    /// </summary>
+    public int AccountId { get; set; }
+
+    /// <summary>
+    /// First name of the user.
+    /// </summary>
+    public string? FirstName { get; set; }
+
+    /// <summary>
+    /// Last name of the user.
+    /// </summary>
+    public string? LastName { get; set; }
+
+    /// <summary>
+    /// Number of purchases made by the user.
+    /// </summary>
+    public int PurchaseCount { get; set; }
+}

--- a/MTA.Application/Services/Interface/IDashboardService.cs
+++ b/MTA.Application/Services/Interface/IDashboardService.cs
@@ -1,0 +1,16 @@
+using MTA.Application.DTOs;
+
+namespace MTA.Application.Services;
+
+/// <summary>
+/// Provides methods for retrieving aggregated dashboard statistics.
+/// </summary>
+public interface IDashboardService
+{
+    /// <summary>
+    /// Retrieves dashboard statistics including user and purchase insights.
+    /// </summary>
+    /// <param name="topCount">Number of top users to include in rankings.</param>
+    /// <returns>The populated dashboard statistics DTO.</returns>
+    Task<DashboardStatisticsDto> GetStatisticsAsync(int topCount = 5);
+}

--- a/MTA.Application/Services/Service/DashboardService.cs
+++ b/MTA.Application/Services/Service/DashboardService.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using MTA.Application.DTOs;
+using MTA.Domain.Entities;
+using MTA.Domain.Interfaces;
+
+namespace MTA.Application.Services;
+
+/// <summary>
+/// Service responsible for providing dashboard statistics.
+/// </summary>
+public class DashboardService : IDashboardService
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<DashboardService> _logger;
+
+    public DashboardService(IUnitOfWork unitOfWork, ILogger<DashboardService> logger)
+    {
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<DashboardStatisticsDto> GetStatisticsAsync(int topCount = 5)
+    {
+        if (topCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(topCount), "Top count must be greater than zero.");
+        }
+
+        try
+        {
+            var totalUsersTask = _unitOfWork.Repository<Account>()
+                .GetQueryable()
+                .AsNoTracking()
+                .CountAsync();
+
+            var courseQuery = _unitOfWork.Repository<UserCourseHistory>()
+                .GetQueryable()
+                .AsNoTracking();
+
+            var packageQuery = _unitOfWork.Repository<PackageHistory>()
+                .GetQueryable()
+                .AsNoTracking();
+
+            var totalCoursePurchasesTask = courseQuery.CountAsync();
+            var totalPackagePurchasesTask = packageQuery.CountAsync();
+
+            var totalTicketsTask = _unitOfWork.Repository<Ticket>()
+                .GetQueryable()
+                .AsNoTracking()
+                .CountAsync();
+
+            var topPackageBuyersTask = packageQuery
+                .GroupBy(ph => ph.AccountId)
+                .Select(group => new TopUserAggregate(group.Key, group.Count()))
+                .OrderByDescending(result => result.PurchaseCount)
+                .ThenBy(result => result.AccountId)
+                .Take(topCount)
+                .ToListAsync();
+
+            var topCourseBuyersTask = courseQuery
+                .GroupBy(uch => uch.AccountId)
+                .Select(group => new TopUserAggregate(group.Key, group.Count()))
+                .OrderByDescending(result => result.PurchaseCount)
+                .ThenBy(result => result.AccountId)
+                .Take(topCount)
+                .ToListAsync();
+
+            await Task.WhenAll(
+                totalUsersTask,
+                totalCoursePurchasesTask,
+                totalPackagePurchasesTask,
+                totalTicketsTask,
+                topPackageBuyersTask,
+                topCourseBuyersTask);
+
+            var aggregatedAccounts = topPackageBuyersTask.Result
+                .Concat(topCourseBuyersTask.Result)
+                .Select(item => item.AccountId)
+                .Distinct()
+                .ToList();
+
+            var accountIdentities = aggregatedAccounts.Count > 0
+                ? await _unitOfWork.Repository<Account>()
+                    .GetQueryable()
+                    .AsNoTracking()
+                    .Where(account => aggregatedAccounts.Contains(account.Id))
+                    .Select(account => new AccountIdentity(
+                        account.Id,
+                        account.UserProfile != null ? account.UserProfile.FirstName : null,
+                        account.UserProfile != null ? account.UserProfile.LastName : null))
+                    .ToListAsync()
+                : new List<AccountIdentity>();
+
+            var accountLookup = accountIdentities.ToDictionary(identity => identity.AccountId);
+
+            return new DashboardStatisticsDto
+            {
+                TotalUsers = totalUsersTask.Result,
+                TotalCoursePurchases = totalCoursePurchasesTask.Result,
+                TotalPackagePurchases = totalPackagePurchasesTask.Result,
+                TotalTickets = totalTicketsTask.Result,
+                TopPackageBuyers = MapAggregates(topPackageBuyersTask.Result, accountLookup),
+                TopCourseBuyers = MapAggregates(topCourseBuyersTask.Result, accountLookup)
+            };
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to retrieve dashboard statistics.");
+            throw;
+        }
+    }
+
+    private static IEnumerable<TopUserPurchaseDto> MapAggregates(
+        IEnumerable<TopUserAggregate> aggregates,
+        IReadOnlyDictionary<int, AccountIdentity> accountLookup) =>
+        aggregates.Select(aggregate =>
+        {
+            accountLookup.TryGetValue(aggregate.AccountId, out var identity);
+
+            return new TopUserPurchaseDto
+            {
+                AccountId = aggregate.AccountId,
+                FirstName = identity?.FirstName,
+                LastName = identity?.LastName,
+                PurchaseCount = aggregate.PurchaseCount
+            };
+        });
+
+    private sealed record TopUserAggregate(int AccountId, int PurchaseCount);
+
+    private sealed record AccountIdentity(int AccountId, string? FirstName, string? LastName);
+}

--- a/MTA.Web/Controllers/DashboardController.cs
+++ b/MTA.Web/Controllers/DashboardController.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using MTA.Application.DTOs;
+using MTA.Application.Services;
+using MTA.Web.Models;
+
+namespace MTA.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class DashboardController : ControllerBase
+{
+    private readonly IDashboardService _dashboardService;
+    private readonly ILogger<DashboardController> _logger;
+
+    public DashboardController(IDashboardService dashboardService, ILogger<DashboardController> logger)
+    {
+        _dashboardService = dashboardService;
+        _logger = logger;
+    }
+
+    [HttpPost("[action]")]
+    [ProducesResponseType(typeof(CustomJsonResult<DashboardStatisticsDto>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(typeof(CustomJsonResult<string>), (int)HttpStatusCode.InternalServerError)]
+    public async Task<ActionResult<CustomJsonResult<DashboardStatisticsDto>>> GetStatistics([FromQuery] int topCount = 5)
+    {
+        try
+        {
+            var statistics = await _dashboardService.GetStatisticsAsync(topCount);
+            return Ok(CustomJsonResult<DashboardStatisticsDto>.SuccessResult(statistics));
+        }
+        catch (ArgumentOutOfRangeException exception)
+        {
+            _logger.LogWarning(exception, "Invalid top count provided for dashboard statistics.");
+            return BadRequest(CustomJsonResult<string>.Failure(exception.Message));
+        }
+        catch (KeyNotFoundException exception)
+        {
+            _logger.LogWarning(exception, "Required data not found while retrieving dashboard statistics.");
+            return NotFound(CustomJsonResult<string>.Failure(exception.Message));
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Unexpected error while retrieving dashboard statistics.");
+            return StatusCode(
+                (int)HttpStatusCode.InternalServerError,
+                CustomJsonResult<string>.Failure("An unexpected error occurred while retrieving dashboard statistics."));
+        }
+    }
+}

--- a/MTA.Web/ServiceCollectionExtensions.cs
+++ b/MTA.Web/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ namespace MTA.Web
         public static IServiceCollection AddApplicationServices(this IServiceCollection services)
         {
             services.AddScoped<IAccountService, AccountService>();
+            services.AddScoped<IDashboardService, DashboardService>();
             services.AddScoped<IAuthService, AuthService>();
             services.AddScoped<ICourseService, CourseService>();
             services.AddScoped<IFAQService, FAQService>();


### PR DESCRIPTION
## Summary
- add DTOs, service contract, and service implementation to gather dashboard metrics for users, packages, courses, and tickets
- register the dashboard service and expose a controller action that returns the aggregated statistics via CustomJsonResult

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fe710c0d448320883067b4006f30c8