### PR TITLE
Allow updating user status through profile update

### DIFF
--- a/MTA.Application/DTOs/UserDto.cs
+++ b/MTA.Application/DTOs/UserDto.cs
@@ -51,6 +51,7 @@ namespace MTA.Application.DTOs.User
         public int? SkillLevelId { get; set; }      // nullable
         public bool? HealthCondition { get; set; }  // nullable
         public string? HealthDescription { get; set; }
+        public int? StatusId { get; set; }          // nullable - updates account status
     }
 
 

--- a/MTA.Application/Services/Service/UserProfileService.cs
+++ b/MTA.Application/Services/Service/UserProfileService.cs
@@ -151,6 +151,16 @@ public class UserProfileService : IUserProfileService
         var user = await _unitOfWork.UserProfiles.GetByIdAsync(id);
         if (user is null) return null;
 
+        if (dto.StatusId.HasValue)
+        {
+            var account = await _unitOfWork.Accounts.GetByIdAsync(user.AccountId);
+            if (account != null && account.StatusId != dto.StatusId.Value)
+            {
+                account.StatusId = dto.StatusId.Value;
+                await _unitOfWork.Accounts.UpdateAsync(account);
+            }
+        }
+
         if (dto.FirstName != null)
             user.FirstName = dto.FirstName.Trim();
 


### PR DESCRIPTION
## Summary
- allow profile updates to carry an optional account status identifier
- update the user profile service to persist account status changes alongside profile edits

## Testing
- dotnet build MTA.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68fe754d167083209a56efac1d866acd