### PR TITLE
Add centralized role-based authorization

### DIFF
--- a/MTA.Domain/Constants/RoleNames.cs
+++ b/MTA.Domain/Constants/RoleNames.cs
@@ -1,0 +1,11 @@
+namespace MTA.Domain.Constants;
+
+/// <summary>
+/// Provides well-known role names used across the application for authorization decisions.
+/// </summary>
+public static class RoleNames
+{
+    public const string Admin = "Admin";
+    public const string Coach = "Coach";
+    public const string Student = "Student";
+}

--- a/MTA.Web/Attributes/AuthorizeRoleAttribute.cs
+++ b/MTA.Web/Attributes/AuthorizeRoleAttribute.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.AspNetCore.Authorization;
+
+namespace MTA.Web.Attributes;
+
+/// <summary>
+/// Provides a strongly typed helper attribute for registering role-based authorization policies.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+public sealed class AuthorizeRoleAttribute : AuthorizeAttribute
+{
+    public AuthorizeRoleAttribute(params string[] roles)
+    {
+        ArgumentNullException.ThrowIfNull(roles);
+
+        var sanitizedRoles = roles
+            .Where(role => !string.IsNullOrWhiteSpace(role))
+            .Select(role => role!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (sanitizedRoles.Length == 0)
+        {
+            throw new ArgumentException("At least one valid role must be specified.", nameof(roles));
+        }
+
+        Policy = BuildPolicyName(sanitizedRoles);
+    }
+
+    [return: NotNull]
+    private static string BuildPolicyName(string[] roles)
+    {
+        if (roles.Length == 1)
+        {
+            return $"Role{roles[0]}";
+        }
+
+        return $"Roles{string.Concat(roles)}";
+    }
+}

--- a/MTA.Web/Controllers/AuthController.cs
+++ b/MTA.Web/Controllers/AuthController.cs
@@ -13,6 +13,7 @@ namespace MTA.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Produces("application/json")]
+[AllowAnonymous]
 public class AuthController : ControllerBase
 {
     private readonly IAuthService _authService;

--- a/MTA.Web/Controllers/CoursesController.cs
+++ b/MTA.Web/Controllers/CoursesController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs;
 using MTA.Application.DTOs.Course;
 using MTA.Application.Services;
+using MTA.Domain.Constants;
 using MTA.Web.Attributes;
 
 namespace MTA.Web.Controllers;
@@ -14,7 +15,7 @@ namespace MTA.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Produces("application/json")]
-//[Authorize]
+[Authorize]
 public class CoursesController : ControllerBase
 {
     private readonly ICourseService _courseService;
@@ -107,7 +108,7 @@ public class CoursesController : ControllerBase
     /// <response code="403">If the user doesn't have required role</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpPost]
-    //[Authorize(Policy = "RolesAdminCoach")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -209,7 +210,7 @@ public class CoursesController : ControllerBase
     /// <response code="400">If the filter parameters are invalid</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpPost("filter")]
-    //[AllowAnonymous]
+    [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]

--- a/MTA.Web/Controllers/FAQController.cs
+++ b/MTA.Web/Controllers/FAQController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs;
 using MTA.Application.Services;
+using MTA.Domain.Constants;
 using MTA.Web.Attributes;
 
 namespace MTA.Web.Controllers;
@@ -13,7 +14,7 @@ namespace MTA.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Produces("application/json")]
-//[Authorize(Policy = "RolesAdminCoach")]
+[Authorize]
 public class FAQController : ControllerBase
 {
     private readonly IFAQService _faqService;
@@ -105,6 +106,7 @@ public class FAQController : ControllerBase
     /// <response code="403">If the user doesn't have required role</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpPost("CreateCategory")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -139,6 +141,7 @@ public class FAQController : ControllerBase
     /// <response code="403">If the user doesn't have required role</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpPut("UpdateCategory/{id}")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -177,6 +180,7 @@ public class FAQController : ControllerBase
     /// <response code="403">If the user doesn't have required role</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpDelete("DeleteCategory/{id}")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -312,6 +316,7 @@ public class FAQController : ControllerBase
     /// <response code="403">If the user doesn't have required role</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpPost("CreateQuestion")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -346,6 +351,7 @@ public class FAQController : ControllerBase
     /// <response code="403">If the user doesn't have required role</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpPut("UpdateQuestion/{id}")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -383,6 +389,7 @@ public class FAQController : ControllerBase
     /// <response code="403">If the user doesn't have required role</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpDelete("DeleteQuestion/{id}")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/MTA.Web/Controllers/LessonController.cs
+++ b/MTA.Web/Controllers/LessonController.cs
@@ -2,13 +2,15 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs;
 using MTA.Application.Services;
+using MTA.Domain.Constants;
+using MTA.Web.Attributes;
 using Microsoft.Extensions.Logging;
 
 namespace MTA.Web.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-//[Authorize]
+[Authorize]
 public class LessonController : ControllerBase
 {
     private readonly ILessonService _lessonService;
@@ -88,7 +90,7 @@ public class LessonController : ControllerBase
     /// Create new lesson
     /// </summary>
     [HttpPost]
-    //[Authorize(Roles = "Admin")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     public async Task<ActionResult<LessonDto>> CreateLesson([FromForm] CreateLessonDto lessonDto)
     {
         try
@@ -114,7 +116,7 @@ public class LessonController : ControllerBase
     /// Update existing lesson
     /// </summary>
     [HttpPut("{id}")]
-   // [Authorize(Roles = "Admin")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     public async Task<ActionResult<LessonDto>> UpdateLesson(int id, [FromForm] UpdateLessonDto lessonDto)
     {
         try
@@ -143,7 +145,7 @@ public class LessonController : ControllerBase
     /// Delete lesson
     /// </summary>
     [HttpDelete("{id}")]
-    //[Authorize(Roles = "Admin")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     public async Task<ActionResult> DeleteLesson(int id)
     {
         try
@@ -173,7 +175,7 @@ public class LessonController : ControllerBase
     /// Change lesson course
     /// </summary>
     [HttpPatch("{id}/course")]
-    //[Authorize(Roles = "Admin")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     public async Task<ActionResult<LessonDto>> ChangeCourse(int id, [FromBody] int courseId)
     {
         try
@@ -196,7 +198,7 @@ public class LessonController : ControllerBase
     /// Update lesson order
     /// </summary>
     [HttpPatch("{id}/order")]
-    //[Authorize(Roles = "Admin")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     public async Task<ActionResult<LessonDto>> UpdateOrder(int id, [FromBody] int order)
     {
         try

--- a/MTA.Web/Controllers/LevelsController.cs
+++ b/MTA.Web/Controllers/LevelsController.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs;
+using MTA.Domain.Constants;
 using MTA.Domain.Entities;
 using MTA.Domain.Interfaces;
 using MTA.Web.Attributes;
@@ -14,7 +15,7 @@ namespace MTA.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Produces("application/json")]
-//[Authorize(Policy = "RolesAdminCoach")]
+[Authorize]
 public class LevelsController : ControllerBase
 {
     private readonly IUnitOfWork _unitOfWork;
@@ -104,6 +105,7 @@ public class LevelsController : ControllerBase
     /// <response code="403">If the user doesn't have required role</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpPost]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -143,6 +145,7 @@ public class LevelsController : ControllerBase
     /// <response code="404">If the skill level was not found</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpPut("{id}")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -183,6 +186,7 @@ public class LevelsController : ControllerBase
     /// <response code="404">If the skill level was not found</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpDelete("{id}")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]

--- a/MTA.Web/Controllers/LookupController.cs
+++ b/MTA.Web/Controllers/LookupController.cs
@@ -1,11 +1,15 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs;
 using MTA.Application.Services;
+using MTA.Domain.Constants;
+using MTA.Web.Attributes;
 
-namespace MTA.API.Controllers
+namespace MTA.Web.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class LookupController : ControllerBase
     {
         private readonly ILookupService _lookupService;
@@ -16,6 +20,7 @@ namespace MTA.API.Controllers
         }
 
         [HttpGet]
+        [AllowAnonymous]
         public async Task<ActionResult<PaginatedResult<LookupDto>>> GetAll(
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 10,
@@ -27,6 +32,7 @@ namespace MTA.API.Controllers
         }
 
         [HttpGet("{id:int}")]
+        [AllowAnonymous]
         public async Task<ActionResult<LookupDto>> GetById(int id)
         {
             var lookup = await _lookupService.GetByIdAsync(id);
@@ -37,14 +43,15 @@ namespace MTA.API.Controllers
         }
 
         [HttpGet("category/{category}")]
+        [AllowAnonymous]
         public async Task<ActionResult<IEnumerable<LookupDto>>> GetByCategory(string category)
         {
             var result = await _lookupService.GetByCategoryAsync(category);
             return Ok(result);
         }
 
-
         [HttpPost]
+        [AuthorizeRole(RoleNames.Admin)]
         public async Task<ActionResult<LookupDto>> Create([FromBody] CreateLookupDto dto)
         {
             if (dto == null)
@@ -55,6 +62,7 @@ namespace MTA.API.Controllers
         }
 
         [HttpPut("{id:int}")]
+        [AuthorizeRole(RoleNames.Admin)]
         public async Task<ActionResult<LookupDto>> Update(int id, [FromBody] LookupDto dto)
         {
             if (dto == null)
@@ -72,6 +80,7 @@ namespace MTA.API.Controllers
         }
 
         [HttpDelete("{id:int}")]
+        [AuthorizeRole(RoleNames.Admin)]
         public async Task<ActionResult> Delete(int id)
         {
             var success = await _lookupService.DeleteAsync(id);
@@ -82,11 +91,11 @@ namespace MTA.API.Controllers
         }
 
         [HttpGet("categories")]
+        [AllowAnonymous]
         public async Task<ActionResult<IEnumerable<string>>> GetCategories()
         {
             var result = await _lookupService.GetAllCategoriesAsync();
             return Ok(result);
         }
-
     }
 }

--- a/MTA.Web/Controllers/MediaFileController.cs
+++ b/MTA.Web/Controllers/MediaFileController.cs
@@ -4,13 +4,15 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using MTA.Application.DTOs;
 using MTA.Application.Services;
+using MTA.Domain.Constants;
+using MTA.Web.Attributes;
 
 namespace MTA.Web.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
     [Produces("application/json")]
-    //[Authorize]
+    [Authorize]
     public class MediaFileController : ControllerBase
     {
         private readonly IMediaFileService _mediaFileService;
@@ -26,6 +28,7 @@ namespace MTA.Web.Controllers
 
         #region Create / Upload
         [HttpPost("upload")]
+        [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -49,6 +52,7 @@ namespace MTA.Web.Controllers
 
         #region Get All / Search / Filter
         [HttpGet]
+        [AllowAnonymous]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetAll(
             int page = 1,
@@ -65,6 +69,7 @@ namespace MTA.Web.Controllers
 
         #region Get By ID
         [HttpGet("{id}")]
+        [AllowAnonymous]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetById(int id)
@@ -79,6 +84,7 @@ namespace MTA.Web.Controllers
 
         #region Update / Replace File
         [HttpPut("{id}")]
+        [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -108,6 +114,7 @@ namespace MTA.Web.Controllers
 
         #region Delete
         [HttpDelete("{id}")]
+        [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Delete(int id)
@@ -122,6 +129,7 @@ namespace MTA.Web.Controllers
 
         #region Download
         [HttpGet("{id}/download")]
+        [AllowAnonymous]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Download(int id)

--- a/MTA.Web/Controllers/MessageController.cs
+++ b/MTA.Web/Controllers/MessageController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs;
 using MTA.Application.Services;
 using MTA.Web.Attributes;
+using MTA.Domain.Constants;
 
 namespace MTA.Web.Controllers;
 
@@ -12,7 +13,7 @@ namespace MTA.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Produces("application/json")]
-//[Authorize]
+[Authorize]
 public class MessageController : ControllerBase
 {
     private readonly IMessageService _messageService;
@@ -127,6 +128,7 @@ public class MessageController : ControllerBase
     /// <response code="404">If the message was not found</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpPut("{id}")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -160,6 +162,7 @@ public class MessageController : ControllerBase
     /// <response code="404">If the message was not found</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpDelete("{id}")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]

--- a/MTA.Web/Controllers/PackageController.cs
+++ b/MTA.Web/Controllers/PackageController.cs
@@ -3,12 +3,14 @@ using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs;
 using MTA.Application.Services;
 using Microsoft.Extensions.Logging;
+using MTA.Domain.Constants;
+using MTA.Web.Attributes;
 
 namespace MTA.Web.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-//[Authorize]
+[Authorize]
 public class PackageController : ControllerBase
 {
     private readonly IPackageService _packageService;
@@ -26,6 +28,7 @@ public class PackageController : ControllerBase
     /// Get all packages with pagination and filtering
     /// </summary>
     [HttpGet]
+    [AllowAnonymous]
     public async Task<ActionResult<PaginatedResult<PackageDto>>> GetPackages(
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 10,
@@ -50,6 +53,7 @@ public class PackageController : ControllerBase
     /// Get package by ID
     /// </summary>
     [HttpGet("{id}")]
+    [AllowAnonymous]
     public async Task<ActionResult<PackageDto>> GetPackage(int id)
     {
         try
@@ -109,7 +113,7 @@ public class PackageController : ControllerBase
     /// Create new package
     /// </summary>
     [HttpPost]
-    //[Authorize(Roles = "Admin")]
+    [AuthorizeRole(RoleNames.Admin)]
     public async Task<ActionResult<PackageDto>> CreatePackage([FromBody] CreatePackageDto packageDto)
     {
         try
@@ -135,7 +139,7 @@ public class PackageController : ControllerBase
     /// Update existing package
     /// </summary>
     [HttpPut("{id}")]
-    //[Authorize(Roles = "Admin")]
+    [AuthorizeRole(RoleNames.Admin)]
     public async Task<ActionResult<PackageDto>> UpdatePackage(int id, [FromBody] PackageDto packageDto)
     {
         try
@@ -164,7 +168,7 @@ public class PackageController : ControllerBase
     /// Delete package
     /// </summary>
     [HttpDelete("{id}")]
-    //[Authorize(Roles = "Admin")]
+    [AuthorizeRole(RoleNames.Admin)]
     public async Task<ActionResult> DeletePackage(int id)
     {
         try

--- a/MTA.Web/Controllers/PackageHistoryController.cs
+++ b/MTA.Web/Controllers/PackageHistoryController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs;
 using MTA.Application.Services;
 using MTA.Web.Attributes;
+using MTA.Domain.Constants;
 
 namespace MTA.Web.Controllers;
 
@@ -12,7 +13,7 @@ namespace MTA.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Produces("application/json")]
-//[Authorize]
+[Authorize]
 public class PackageHistoryController : ControllerBase
 {
     private readonly IPackageHistoryService _packageHistoryService;
@@ -95,6 +96,7 @@ public class PackageHistoryController : ControllerBase
     /// <response code="400">If the package history data is invalid</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpPost]
+    [AuthorizeRole(RoleNames.Admin)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -125,6 +127,7 @@ public class PackageHistoryController : ControllerBase
     /// <response code="404">If the package history was not found</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpPut("{id}")]
+    [AuthorizeRole(RoleNames.Admin)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -158,6 +161,7 @@ public class PackageHistoryController : ControllerBase
     /// <response code="404">If the package history was not found</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpDelete("{id}")]
+    [AuthorizeRole(RoleNames.Admin)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]

--- a/MTA.Web/Controllers/PermissionController.cs
+++ b/MTA.Web/Controllers/PermissionController.cs
@@ -3,12 +3,14 @@ using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs;
 using MTA.Application.Services;
 using Microsoft.Extensions.Logging;
+using MTA.Domain.Constants;
+using MTA.Web.Attributes;
 
 namespace MTA.Web.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-//[Authorize(Roles = "Admin")]
+[AuthorizeRole(RoleNames.Admin)]
 public class PermissionController : ControllerBase
 {
     private readonly IPermissionService _permissionService;

--- a/MTA.Web/Controllers/ProfileController.cs
+++ b/MTA.Web/Controllers/ProfileController.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs.User;
@@ -10,6 +11,7 @@ namespace MTA.Web.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Produces("application/json")]
+    [Authorize]
     public class ProfileController : ControllerBase
     {
         private readonly IAccountService _accountService;

--- a/MTA.Web/Controllers/RolePermissionController.cs
+++ b/MTA.Web/Controllers/RolePermissionController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs;
 using MTA.Application.Services;
 using MTA.Web.Attributes;
+using MTA.Domain.Constants;
 
 namespace MTA.Web.Controllers;
 
@@ -12,7 +13,7 @@ namespace MTA.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Produces("application/json")]
-//[Authorize(Roles = "Admin")]
+[AuthorizeRole(RoleNames.Admin)]
 public class RolePermissionController : ControllerBase
 {
     private readonly IRolePermissionService _rolePermissionService;

--- a/MTA.Web/Controllers/RolesController.cs
+++ b/MTA.Web/Controllers/RolesController.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MTA.Application.DTOs;
+using MTA.Domain.Constants;
 using MTA.Domain.Entities;
 using MTA.Domain.Interfaces;
 using MTA.Web.Attributes;
@@ -14,7 +15,7 @@ namespace MTA.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Produces("application/json")]
-//[Authorize(Roles = "Admin")]
+[AuthorizeRole(RoleNames.Admin)]
 public class RolesController : ControllerBase
 {
     private readonly IUnitOfWork _unitOfWork;

--- a/MTA.Web/Controllers/SiteRulesController.cs
+++ b/MTA.Web/Controllers/SiteRulesController.cs
@@ -1,11 +1,16 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using MTA.Application.DTOs;
 using MTA.Application.Services;
+using MTA.Domain.Constants;
+using MTA.Web.Attributes;
 
 namespace MTA.Web.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class SiteRulesController : ControllerBase
     {
         private readonly ILookupService _lookupService;
@@ -19,6 +24,7 @@ namespace MTA.Web.Controllers
 
         // GET: api/siterules
         [HttpGet("SiteRules")]
+        [AllowAnonymous]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<ActionResult<IEnumerable<LookupDto>>> GetSiteRules([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
         {
@@ -27,6 +33,7 @@ namespace MTA.Web.Controllers
         }
 
         [HttpGet("category")]
+        [AllowAnonymous]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<ActionResult<IEnumerable<LookupDto>>> GetCategory([FromQuery] string CategoryName)
         {
@@ -35,6 +42,7 @@ namespace MTA.Web.Controllers
         }
 
         [HttpGet("categories")]
+        [AllowAnonymous]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<ActionResult<IEnumerable<string>>> Categories()
         {
@@ -44,6 +52,7 @@ namespace MTA.Web.Controllers
 
         // GET: api/siterules/5
         [HttpGet("{id}")]
+        [AllowAnonymous]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<LookupDto>> GetById(int id)
@@ -57,6 +66,7 @@ namespace MTA.Web.Controllers
 
         // POST: api/siterules
         [HttpPost]
+        [AuthorizeRole(RoleNames.Admin)]
         [ProducesResponseType(StatusCodes.Status201Created)]
         public async Task<ActionResult<LookupDto>> Create([FromBody] CreateLookupDto dto)
         {
@@ -68,6 +78,7 @@ namespace MTA.Web.Controllers
 
         // PUT: api/siterules/5
         [HttpPut("{id}")]
+        [AuthorizeRole(RoleNames.Admin)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Update(int id, [FromBody] LookupDto dto)
@@ -84,6 +95,7 @@ namespace MTA.Web.Controllers
 
         // DELETE: api/siterules/5
         [HttpDelete("{id}")]
+        [AuthorizeRole(RoleNames.Admin)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Delete(int id)
@@ -98,8 +110,5 @@ namespace MTA.Web.Controllers
 
             return NoContent();
         }
-
-
     }
-
 }

--- a/MTA.Web/Controllers/TicketsController.cs
+++ b/MTA.Web/Controllers/TicketsController.cs
@@ -2,9 +2,11 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using MTA.Application.DTOs;
+using MTA.Domain.Constants;
 using MTA.Domain.Entities;
 using MTA.Domain.Interfaces;
 using MTA.Infrastructure.Data;
+using MTA.Web.Attributes;
 using System.Security.Claims;
 
 namespace MTA.Web.Controllers;
@@ -15,6 +17,7 @@ namespace MTA.Web.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Produces("application/json")]
+[Authorize]
 public class TicketsController : ControllerBase
 {
     private readonly IUnitOfWork _unitOfWork;
@@ -33,6 +36,7 @@ public class TicketsController : ControllerBase
     /// <response code="200">Returns the list of tickets</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpGet]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult<IEnumerable<TicketDto>>> GetTickets()
@@ -80,6 +84,7 @@ public class TicketsController : ControllerBase
     /// <response code="404">If the ticket was not found</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpGet("{id}")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -236,6 +241,7 @@ public class TicketsController : ControllerBase
     /// <response code="404">If the ticket was not found</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpPut("{id}")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -280,6 +286,7 @@ public class TicketsController : ControllerBase
     /// <response code="404">If the ticket was not found</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpDelete("{id}")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -316,6 +323,7 @@ public class TicketsController : ControllerBase
     /// <response code="200">Returns the list of user tickets</response>
     /// <response code="500">If there was an internal server error</response>
     [HttpGet("user/{userId}")]
+    [AuthorizeRole(RoleNames.Admin, RoleNames.Coach)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult<IEnumerable<TicketDto>>> GetTicketsByUser(int userId)

--- a/MTA.Web/Controllers/UserController.cs
+++ b/MTA.Web/Controllers/UserController.cs
@@ -5,12 +5,14 @@ using MTA.Application.DTOs.User;
 using MTA.Application.Services;
 using MTA.Domain.Entities;
 using System.Security.Claims;
+using MTA.Domain.Constants;
+using MTA.Web.Attributes;
 
 namespace MTA.Web.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-//[Authorize]
+[Authorize]
 public class UserController : ControllerBase
 {
     private readonly IUserProfileService _userProfileService;
@@ -33,7 +35,7 @@ public class UserController : ControllerBase
     /// Get all users with pagination and simple filtering
     /// </summary>
     [HttpGet]
-    //[Authorize(Roles = "Admin")]
+    [AuthorizeRole(RoleNames.Admin)]
     public async Task<ActionResult<PaginatedResult<AccountDto>>> GetUsers(
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 10,
@@ -68,6 +70,7 @@ public class UserController : ControllerBase
     /// Get user details by ID
     /// </summary>
     [HttpGet("{id}")]
+    [AuthorizeRole(RoleNames.Admin)]
     public async Task<ActionResult<AccountDto>> GetUser(int id)
     {
         try
@@ -96,6 +99,7 @@ public class UserController : ControllerBase
     /// Update user
     /// </summary>
     [HttpPut("{id}")]
+    [AuthorizeRole(RoleNames.Admin)]
     public async Task<ActionResult<UserProfileDto>> UpdateUser(int id, [FromForm] UpdateUserProfileDto updateDto)
     {
         try
@@ -125,7 +129,7 @@ public class UserController : ControllerBase
     /// Delete or deactivate user
     /// </summary>
     [HttpDelete("{id}")]
-    //[Authorize(Roles = "Admin")]
+    [AuthorizeRole(RoleNames.Admin)]
     public async Task<ActionResult> DeleteUser(int id)
     {
         try
@@ -151,6 +155,7 @@ public class UserController : ControllerBase
     /// Update user avatar
     /// </summary>
     [HttpPatch("{id}/avatar")]
+    [AuthorizeRole(RoleNames.Admin)]
     public async Task<ActionResult<UserProfileDto>> UpdateAvatar(int id, [FromBody] string ImageUrl)
     {
         try

--- a/MTA.Web/Extensions/AuthorizationServiceCollectionExtensions.cs
+++ b/MTA.Web/Extensions/AuthorizationServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using MTA.Web.Attributes;
+
+namespace MTA.Web.Extensions;
+
+/// <summary>
+/// Extension methods for registering authorization services and policies.
+/// </summary>
+public static class AuthorizationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Configures the application's role-based authorization infrastructure.
+    /// </summary>
+    /// <param name="services">The dependency injection container.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddRoleBasedAuthorization(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped<IAuthorizationHandler, CustomAuthorizationHandler>();
+        services.AddSingleton<IAuthorizationPolicyProvider, CustomAuthorizationPolicyProvider>();
+
+        services.AddAuthorization();
+
+        return services;
+    }
+}

--- a/MTA.Web/Program.cs
+++ b/MTA.Web/Program.cs
@@ -8,6 +8,7 @@ using MTA.Infrastructure.Data;
 using MTA.Infrastructure.Persistence;
 using MTA.Web;
 using MTA.Web.Attributes;
+using MTA.Web.Extensions;
 using System.Security.Claims;
 using System.Text;
 
@@ -101,31 +102,9 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         };
     });
 
-// Authorization
-// 1. Register the custom authorization handler
-builder.Services.AddScoped<IAuthorizationHandler, CustomAuthorizationHandler>();
-
 builder.Services.AddValidatorsFromAssemblyContaining<RoleValidator>();
 
-// 2. Register custom policy provider
-builder.Services.AddSingleton<IAuthorizationPolicyProvider, CustomAuthorizationPolicyProvider>();
-
-
-
-// 3. (Optional) Add default policies if needed
-builder.Services.AddAuthorization(options =>
-{
-    // Example default policy
-    options.AddPolicy("RoleAdmin", policy =>
-    {
-        policy.Requirements.Add(new RoleRequirement("Admin"));
-    });
-
-    options.AddPolicy("RoleCoach", policy =>
-    {
-        policy.Requirements.Add(new RoleRequirement("Coach"));
-    });
-});
+builder.Services.AddRoleBasedAuthorization();
 
 // Add persistence services
 builder.Services.AddPersistenceServices(builder.Configuration);


### PR DESCRIPTION
## Summary
- add reusable role constants and an AuthorizeRole attribute for policy naming
- register role-based authorization services via a new service collection extension
- secure API controllers with authorize/allow anonymous annotations and scoped role policies

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fe770dd994832099216b54c4eff978