### PR TITLE
Remove media file URL list from message responses

### DIFF
--- a/MTA.Application/DTOs/MessageDto.cs
+++ b/MTA.Application/DTOs/MessageDto.cs
@@ -47,7 +47,6 @@ public class MessageDto : BaseDto
 	/// </summary>
 	public string? SenderImage { get; set; }
     public List<MediaFileDto>? MediaFiles { get; set; }
-    public List<string> MediaFileUrls { get; set; } = new List<string>();
 
 }
 

--- a/MTA.Application/Mapping/MessageMappingProfile.cs
+++ b/MTA.Application/Mapping/MessageMappingProfile.cs
@@ -25,9 +25,6 @@ public class MessageMappingProfile : BaseMappingProfile
             // ???? MediaFile DTO??
             .ForMember(dest => dest.MediaFiles, opt => opt.MapFrom(src => src.MediaFiles.Select(mf => mf.MediaFile)))
 
-            // ???? URL ??????? ???? ????? ?????
-            .ForMember(dest => dest.MediaFileUrls, opt => opt.MapFrom(src => src.MediaFiles.Select(mf => mf.MediaFile.Url).ToList()))
-
             .ForMember(dest => dest.CreatedAt, opt => opt.MapFrom(src => src.CreatedAt))
             .ForMember(dest => dest.UpdatedAt, opt => opt.MapFrom(src => src.UpdatedAt));
 

--- a/MTA.Application/Mapping/SupportMappingProfile.cs
+++ b/MTA.Application/Mapping/SupportMappingProfile.cs
@@ -47,8 +47,7 @@ public class SupportMappingProfile : BaseMappingProfile
             .ForMember(dest => dest.SenderFirstName, opt => opt.MapFrom(src => src.Sender.UserProfile.FirstName))
             .ForMember(dest => dest.SenderLastName, opt => opt.MapFrom(src => src.Sender.UserProfile.LastName))
             .ForMember(dest => dest.SenderImage, opt => opt.MapFrom(src => src.Sender.MediaFile != null ? src.Sender.MediaFile.Url : null))
-            .ForMember(dest => dest.MediaFiles, opt => opt.MapFrom(src => src.MediaFiles.Select(mm => mm.MediaFile))) 
-            .ForMember(dest => dest.MediaFileUrls, opt => opt.MapFrom(src => src.MediaFiles.Select(mm => mm.MediaFile.Url))); 
+            .ForMember(dest => dest.MediaFiles, opt => opt.MapFrom(src => src.MediaFiles.Select(mm => mm.MediaFile)));
 
         CreateMap<MessageDto, Message>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))


### PR DESCRIPTION
## Summary
- remove the MediaFileUrls collection from message DTOs
- stop AutoMapper profiles from populating the removed property to avoid duplicate media file data in responses

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ffc9e2b2d48320ba9fc40e151952d4