### PR TITLE
Expose role metadata in current user endpoint

### DIFF
--- a/MTA.Application/DTOs/UserDto.cs
+++ b/MTA.Application/DTOs/UserDto.cs
@@ -154,6 +154,8 @@ namespace MTA.Application.DTOs.User
         public string Email { get; set; } = null!;
         public bool IsActive { get; set; }
         public string? ProfileImageUrl { get; set; }
+        public int RoleId { get; set; }
+        public string RoleTitle { get; set; } = string.Empty;
 
         // UserProfile fields
         public string FirstName { get; set; } = null!;

--- a/MTA.Application/Services/Service/AccountService.cs
+++ b/MTA.Application/Services/Service/AccountService.cs
@@ -175,6 +175,7 @@ public class AccountService : IAccountService
     {
         var account = await _unitOfWork.Accounts.GetQueryable()
             .Include(a => a.MediaFile)
+            .Include(a => a.Role)
             .Include(a => a.UserProfile)
                 .ThenInclude(a=>a.SkillLevel)
             .Include(u => u.UserCourseHistory)
@@ -208,6 +209,8 @@ public class AccountService : IAccountService
             Email = account.Email,
             IsActive = account.IsActive,
             ProfileImageUrl = account.ProfileImagePath ?? account.MediaFile?.Url,
+            RoleId = account.RoleId,
+            RoleTitle = account.Role?.Title ?? string.Empty,
             FirstName = profile?.FirstName ?? string.Empty,
             LastName = profile?.LastName ?? string.Empty,
             DateOfBirth = profile?.DateOfBirth ?? DateTime.MinValue,


### PR DESCRIPTION
## Summary
- extend the `CurrentUserDto` with role identifier and title fields
- populate the new fields by including the account role when loading the current user

## Testing
- `dotnet build` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_69010de2449c8320a6330d38ef87a083