### PR TITLE
Fix SiteRules category handling and DTO

### DIFF
--- a/MTA.Application/DTOs/LookupDto.cs
+++ b/MTA.Application/DTOs/LookupDto.cs
@@ -13,7 +13,6 @@ public class LookupDto
 
 public class CreateLookupDto
 {
-    public int Id { get; set; }
     public string Category { get; set; }
     public string Key { get; set; }
     public string Value { get; set; }

--- a/MTA.Web/Controllers/SiteRulesController.cs
+++ b/MTA.Web/Controllers/SiteRulesController.cs
@@ -49,7 +49,7 @@ namespace MTA.Web.Controllers
         public async Task<ActionResult<LookupDto>> GetById(int id)
         {
             var rule = await _lookupService.GetByIdAsync(id);
-            if (rule == null || rule.Category != "SiteRules")
+            if (rule == null || rule.Category != "SiteRule")
                 return NotFound();
 
             return Ok(rule);
@@ -60,7 +60,7 @@ namespace MTA.Web.Controllers
         [ProducesResponseType(StatusCodes.Status201Created)]
         public async Task<ActionResult<LookupDto>> Create([FromBody] CreateLookupDto dto)
         {
-            dto.Category = "SiteRules"; // همیشه دسته‌بندی رو SiteRules می‌ذاریم
+            dto.Category = "SiteRule"; // همیشه دسته‌بندی رو SiteRule می‌ذاریم
             var created = await _lookupService.CreateAsync(dto);
 
             return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
@@ -73,10 +73,10 @@ namespace MTA.Web.Controllers
         public async Task<IActionResult> Update(int id, [FromBody] LookupDto dto)
         {
             var existing = await _lookupService.GetByIdAsync(id);
-            if (existing == null || existing.Category != "SiteRules")
+            if (existing == null || existing.Category != "SiteRule")
                 return NotFound();
 
-            dto.Category = "SiteRules"; // دسته‌بندی نباید تغییر کنه
+            dto.Category = "SiteRule"; // دسته‌بندی نباید تغییر کنه
             await _lookupService.UpdateAsync(id, dto);
 
             return NoContent();
@@ -89,7 +89,7 @@ namespace MTA.Web.Controllers
         public async Task<IActionResult> Delete(int id)
         {
             var existing = await _lookupService.GetByIdAsync(id);
-            if (existing == null || existing.Category != "SiteRules")
+            if (existing == null || existing.Category != "SiteRule")
                 return NotFound();
 
             var deleted = await _lookupService.DeleteAsync(id);


### PR DESCRIPTION
## Summary
- align the SiteRules controller with the correct "SiteRule" category for lookups
- remove the unused Id field from the CreateLookupDto to avoid confusion when creating records

## Testing
- `dotnet build MTA.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6901a24a87508320bd3fa075f11fd029