### PR TITLE
Simplify SiteRule create and update payloads

### DIFF
--- a/MTA.Application/DTOs/SiteRuleDto.cs
+++ b/MTA.Application/DTOs/SiteRuleDto.cs
@@ -1,0 +1,8 @@
+namespace MTA.Application.DTOs;
+
+public class SiteRuleUpsertDto
+{
+    public string Subject { get; set; } = string.Empty;
+
+    public string Text { get; set; } = string.Empty;
+}

--- a/MTA.Web/Controllers/SiteRulesController.cs
+++ b/MTA.Web/Controllers/SiteRulesController.cs
@@ -58,10 +58,15 @@ namespace MTA.Web.Controllers
         // POST: api/siterules
         [HttpPost]
         [ProducesResponseType(StatusCodes.Status201Created)]
-        public async Task<ActionResult<LookupDto>> Create([FromBody] CreateLookupDto dto)
+        public async Task<ActionResult<LookupDto>> Create([FromBody] SiteRuleUpsertDto dto)
         {
-            dto.Category = "SiteRule"; // همیشه دسته‌بندی رو SiteRule می‌ذاریم
-            var created = await _lookupService.CreateAsync(dto);
+            var createDto = new CreateLookupDto
+            {
+                Category = "SiteRule",
+                Key = dto.Subject,
+                Value = dto.Text
+            };
+            var created = await _lookupService.CreateAsync(createDto);
 
             return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
         }
@@ -70,14 +75,20 @@ namespace MTA.Web.Controllers
         [HttpPut("{id}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> Update(int id, [FromBody] LookupDto dto)
+        public async Task<IActionResult> Update(int id, [FromBody] SiteRuleUpsertDto dto)
         {
             var existing = await _lookupService.GetByIdAsync(id);
             if (existing == null || existing.Category != "SiteRule")
                 return NotFound();
 
-            dto.Category = "SiteRule"; // دسته‌بندی نباید تغییر کنه
-            await _lookupService.UpdateAsync(id, dto);
+            var updateDto = new LookupDto
+            {
+                Id = id,
+                Category = "SiteRule",
+                Key = dto.Subject,
+                Value = dto.Text
+            };
+            await _lookupService.UpdateAsync(id, updateDto);
 
             return NoContent();
         }


### PR DESCRIPTION
## Summary
- add a SiteRuleUpsertDto that only exposes the subject and text fields needed from the frontend
- update SiteRulesController to map the simplified request body to the lookup service with the fixed SiteRule category

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_69022e5e02f08320997ecc206c3d2c1e